### PR TITLE
Add Badge, Kbd, and Spinner components

### DIFF
--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/kbd.tsx
+++ b/components/ui/kbd.tsx
@@ -1,0 +1,44 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const kbdVariants = cva(
+  "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium select-none [&_svg:not([class*='size-'])]:size-3",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-muted text-muted-foreground dark:bg-muted/50 dark:text-muted-foreground/80",
+        dark: "bg-background/20 text-background dark:bg-background/10 dark:text-background/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Kbd({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"kbd"> & VariantProps<typeof kbdVariants>) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(kbdVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+export { Kbd, KbdGroup, kbdVariants };

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils";
+import { LoaderIcon, type LucideProps } from "lucide-react";
+
+export type SpinnerSize = "sm" | "md" | "lg";
+
+type SpinnerProps = LucideProps & {
+  size?: SpinnerSize;
+};
+
+export const Spinner = ({ className, size = "sm", ...props }: SpinnerProps) => (
+  <LoaderIcon
+    className={cn(
+      "size-4 animate-spin",
+      {
+        "text-muted-foreground size-3": size === "sm",
+        "text-muted-foreground/50 size-4": size === "md",
+        "text-muted-foreground/70 size-6": size === "lg",
+      },
+      className
+    )}
+    {...props}
+  />
+);

--- a/content/docs/ui/badge.mdx
+++ b/content/docs/ui/badge.mdx
@@ -1,0 +1,127 @@
+---
+title: Badge
+description: A small label component for status indicators, categories, and counts
+icon: Tag
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Badge } from '@/components/ui/badge';
+
+<div className="my-8 flex flex-wrap gap-4">
+  <Badge>Default</Badge>
+  <Badge variant="secondary">Secondary</Badge>
+  <Badge variant="outline">Outline</Badge>
+  <Badge variant="destructive">Destructive</Badge>
+</div>
+
+A badge component for displaying status indicators, labels, counts, or categories. Useful in notebooks for showing kernel state, cell status, or output metadata.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add badge
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from [shadcn/ui badge](https://ui.shadcn.com/docs/components/badge).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { Badge } from "@/components/ui/badge"
+
+export function Example() {
+  return <Badge>New</Badge>
+}
+```
+
+## Variants
+
+### Default
+
+<div className="my-4 flex gap-4">
+  <Badge>Default</Badge>
+</div>
+
+```tsx
+<Badge>Default</Badge>
+```
+
+### Secondary
+
+<div className="my-4 flex gap-4">
+  <Badge variant="secondary">Secondary</Badge>
+</div>
+
+```tsx
+<Badge variant="secondary">Secondary</Badge>
+```
+
+### Outline
+
+<div className="my-4 flex gap-4">
+  <Badge variant="outline">Outline</Badge>
+</div>
+
+```tsx
+<Badge variant="outline">Outline</Badge>
+```
+
+### Destructive
+
+<div className="my-4 flex gap-4">
+  <Badge variant="destructive">Destructive</Badge>
+</div>
+
+```tsx
+<Badge variant="destructive">Destructive</Badge>
+```
+
+### Ghost
+
+<div className="my-4 flex gap-4">
+  <Badge variant="ghost">Ghost</Badge>
+</div>
+
+```tsx
+<Badge variant="ghost">Ghost</Badge>
+```
+
+### Link
+
+<div className="my-4 flex gap-4">
+  <Badge variant="link">Link</Badge>
+</div>
+
+```tsx
+<Badge variant="link">Link</Badge>
+```
+
+## Notebook Examples
+
+<div className="my-4 flex flex-wrap gap-2">
+  <Badge variant="secondary">Python 3.11</Badge>
+  <Badge variant="outline">Idle</Badge>
+  <Badge>3 outputs</Badge>
+  <Badge variant="destructive">Error</Badge>
+</div>
+
+```tsx
+<Badge variant="secondary">Python 3.11</Badge>
+<Badge variant="outline">Idle</Badge>
+<Badge>3 outputs</Badge>
+<Badge variant="destructive">Error</Badge>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `variant` | `"default" \| "secondary" \| "outline" \| "destructive" \| "ghost" \| "link"` | `"default"` | Visual style variant |
+| `asChild` | `boolean` | `false` | Render as child element using Radix Slot |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLSpanElement>` | — | All standard span attributes |

--- a/content/docs/ui/kbd.mdx
+++ b/content/docs/ui/kbd.mdx
@@ -1,0 +1,175 @@
+---
+title: Kbd
+description: A keyboard key component for displaying keyboard shortcuts and hotkeys
+icon: Keyboard
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
+
+<div className="my-8 flex flex-wrap items-center gap-4">
+  <Kbd>Shift</Kbd>
+  <Kbd>Enter</Kbd>
+  <KbdGroup>
+    <Kbd>Cmd</Kbd>
+    <Kbd>K</Kbd>
+  </KbdGroup>
+</div>
+
+A keyboard key component for displaying keyboard shortcuts and hotkeys. Essential for notebook interfaces where keyboard shortcuts are commonly used for cell execution, navigation, and editing.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://elements.nteract.io/r/kbd.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from this repository's `components/ui/kbd.tsx`.
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+
+export function Example() {
+  return (
+    <KbdGroup>
+      <Kbd>Shift</Kbd>
+      <Kbd>Enter</Kbd>
+    </KbdGroup>
+  )
+}
+```
+
+## Single Key
+
+<div className="my-4 flex gap-4">
+  <Kbd>Enter</Kbd>
+  <Kbd>Esc</Kbd>
+  <Kbd>Tab</Kbd>
+  <Kbd>Space</Kbd>
+</div>
+
+```tsx
+<Kbd>Enter</Kbd>
+<Kbd>Esc</Kbd>
+<Kbd>Tab</Kbd>
+<Kbd>Space</Kbd>
+```
+
+## Key Combinations
+
+Use `KbdGroup` to display key combinations:
+
+<div className="my-4 flex flex-wrap gap-6">
+  <KbdGroup>
+    <Kbd>Shift</Kbd>
+    <Kbd>Enter</Kbd>
+  </KbdGroup>
+  <KbdGroup>
+    <Kbd>Cmd</Kbd>
+    <Kbd>S</Kbd>
+  </KbdGroup>
+  <KbdGroup>
+    <Kbd>Ctrl</Kbd>
+    <Kbd>Alt</Kbd>
+    <Kbd>Delete</Kbd>
+  </KbdGroup>
+</div>
+
+```tsx
+<KbdGroup>
+  <Kbd>Shift</Kbd>
+  <Kbd>Enter</Kbd>
+</KbdGroup>
+
+<KbdGroup>
+  <Kbd>Cmd</Kbd>
+  <Kbd>S</Kbd>
+</KbdGroup>
+
+<KbdGroup>
+  <Kbd>Ctrl</Kbd>
+  <Kbd>Alt</Kbd>
+  <Kbd>Delete</Kbd>
+</KbdGroup>
+```
+
+## Variants
+
+### Default
+
+<div className="my-4 flex gap-4">
+  <Kbd>Default</Kbd>
+</div>
+
+```tsx
+<Kbd>Default</Kbd>
+```
+
+### Dark
+
+For use on dark backgrounds:
+
+<div className="my-4 flex gap-4 bg-foreground p-4 rounded-md">
+  <Kbd variant="dark">Dark</Kbd>
+  <KbdGroup>
+    <Kbd variant="dark">Cmd</Kbd>
+    <Kbd variant="dark">K</Kbd>
+  </KbdGroup>
+</div>
+
+```tsx
+<Kbd variant="dark">Dark</Kbd>
+```
+
+## Notebook Shortcuts
+
+Common notebook keyboard shortcuts:
+
+<div className="my-4 space-y-2">
+  <div className="flex items-center gap-4">
+    <KbdGroup>
+      <Kbd>Shift</Kbd>
+      <Kbd>Enter</Kbd>
+    </KbdGroup>
+    <span className="text-muted-foreground text-sm">Run cell and advance</span>
+  </div>
+  <div className="flex items-center gap-4">
+    <KbdGroup>
+      <Kbd>Cmd</Kbd>
+      <Kbd>Enter</Kbd>
+    </KbdGroup>
+    <span className="text-muted-foreground text-sm">Run cell</span>
+  </div>
+  <div className="flex items-center gap-4">
+    <Kbd>Esc</Kbd>
+    <span className="text-muted-foreground text-sm">Enter command mode</span>
+  </div>
+  <div className="flex items-center gap-4">
+    <Kbd>Enter</Kbd>
+    <span className="text-muted-foreground text-sm">Enter edit mode</span>
+  </div>
+</div>
+
+## Props
+
+### Kbd
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `variant` | `"default" \| "dark"` | `"default"` | Visual style variant |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLElement>` | — | All standard kbd attributes |
+
+### KbdGroup
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "UI",
-  "pages": ["button", "input"]
+  "pages": ["badge", "button", "input", "kbd", "spinner"]
 }

--- a/content/docs/ui/spinner.mdx
+++ b/content/docs/ui/spinner.mdx
@@ -1,0 +1,114 @@
+---
+title: Spinner
+description: A loading spinner component for indicating async operations
+icon: Loader
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Spinner } from '@/components/ui/spinner';
+
+<div className="my-8 flex items-center gap-8">
+  <Spinner size="sm" />
+  <Spinner size="md" />
+  <Spinner size="lg" />
+</div>
+
+A loading spinner component for indicating async operations. Used in notebooks to show kernel execution state, cell running status, and other loading states.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://elements.nteract.io/r/spinner.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from this repository's `components/ui/spinner.tsx`.
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { Spinner } from "@/components/ui/spinner"
+
+export function Example() {
+  return <Spinner />
+}
+```
+
+## Sizes
+
+<div className="my-4 flex items-center gap-8">
+  <div className="flex flex-col items-center gap-2">
+    <Spinner size="sm" />
+    <span className="text-xs text-muted-foreground">sm</span>
+  </div>
+  <div className="flex flex-col items-center gap-2">
+    <Spinner size="md" />
+    <span className="text-xs text-muted-foreground">md</span>
+  </div>
+  <div className="flex flex-col items-center gap-2">
+    <Spinner size="lg" />
+    <span className="text-xs text-muted-foreground">lg</span>
+  </div>
+</div>
+
+```tsx
+<Spinner size="sm" />
+<Spinner size="md" />
+<Spinner size="lg" />
+```
+
+## With Text
+
+<div className="my-4 flex items-center gap-2">
+  <Spinner size="sm" />
+  <span className="text-sm text-muted-foreground">Loading...</span>
+</div>
+
+```tsx
+<div className="flex items-center gap-2">
+  <Spinner size="sm" />
+  <span className="text-sm text-muted-foreground">Loading...</span>
+</div>
+```
+
+## Notebook Examples
+
+### Cell Execution
+
+<div className="my-4 flex items-center gap-2 text-sm">
+  <Spinner size="sm" />
+  <span className="text-muted-foreground">Running cell...</span>
+</div>
+
+```tsx
+<div className="flex items-center gap-2">
+  <Spinner size="sm" />
+  <span className="text-muted-foreground">Running cell...</span>
+</div>
+```
+
+### Kernel Starting
+
+<div className="my-4 flex items-center gap-2 text-sm">
+  <Spinner size="md" />
+  <span className="text-muted-foreground">Starting kernel...</span>
+</div>
+
+```tsx
+<div className="flex items-center gap-2">
+  <Spinner size="md" />
+  <span className="text-muted-foreground">Starting kernel...</span>
+</div>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `size` | `"sm" \| "md" \| "lg"` | `"sm"` | Spinner size |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `LucideProps` | — | All Lucide icon props |

--- a/registry.json
+++ b/registry.json
@@ -105,6 +105,32 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "kbd",
+      "type": "registry:ui",
+      "title": "Kbd",
+      "description": "A keyboard key component for displaying keyboard shortcuts and hotkeys. Essential for notebook interfaces.",
+      "dependencies": ["class-variance-authority"],
+      "files": [
+        {
+          "path": "components/ui/kbd.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "spinner",
+      "type": "registry:ui",
+      "title": "Spinner",
+      "description": "A loading spinner component for indicating async operations like kernel execution and cell running status.",
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "components/ui/spinner.tsx",
+          "type": "registry:ui"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add **Badge** component via shadcn CLI for status indicators and labels
- Add **Kbd** component for displaying keyboard shortcuts (from intheloop)
- Add **Spinner** component for loading states during kernel execution (from intheloop)
- Add MDX documentation with interactive examples for all three components
- Register Kbd and Spinner in `registry.json` for distribution

Closes #6

## Test plan

- [x] Verify `pnpm run types:check` passes
- [x] Verify Badge renders with all variants (default, secondary, outline, destructive, ghost, link)
- [x] Verify Kbd renders single keys and KbdGroup renders combinations
- [x] Verify Spinner renders at all sizes (sm, md, lg) with animation
- [x] Check MDX docs render correctly at `/docs/ui/badge`, `/docs/ui/kbd`, `/docs/ui/spinner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)