### PR TITLE
Add Card, Popover, and Tooltip components

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/content/docs/ui/card.mdx
+++ b/content/docs/ui/card.mdx
@@ -1,0 +1,198 @@
+---
+title: Card
+description: A container component for grouping related content with optional header and footer
+icon: CreditCard
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter, CardAction } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+<div className="my-8">
+  <Card className="w-full max-w-sm">
+    <CardHeader>
+      <CardTitle>Card Title</CardTitle>
+      <CardDescription>Card description goes here</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <p>Card content and body text.</p>
+    </CardContent>
+    <CardFooter>
+      <Button size="sm">Action</Button>
+    </CardFooter>
+  </Card>
+</div>
+
+A flexible container component for grouping related content. Cards can include headers, content areas, and footers for consistent layout patterns.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add card
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from [shadcn/ui card](https://ui.shadcn.com/docs/components/card).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card"
+
+export function Example() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Description</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>Content goes here.</p>
+      </CardContent>
+      <CardFooter>
+        <p>Footer</p>
+      </CardFooter>
+    </Card>
+  )
+}
+```
+
+## Examples
+
+### Simple Card
+
+<div className="my-4">
+  <Card className="w-full max-w-sm">
+    <CardContent className="pt-6">
+      <p>A simple card with just content.</p>
+    </CardContent>
+  </Card>
+</div>
+
+```tsx
+<Card>
+  <CardContent className="pt-6">
+    <p>A simple card with just content.</p>
+  </CardContent>
+</Card>
+```
+
+### With Header Action
+
+<div className="my-4">
+  <Card className="w-full max-w-sm">
+    <CardHeader>
+      <CardTitle>Notifications</CardTitle>
+      <CardDescription>You have 3 unread messages</CardDescription>
+      <CardAction>
+        <Button variant="outline" size="sm">View All</Button>
+      </CardAction>
+    </CardHeader>
+    <CardContent>
+      <p>Recent activity will appear here.</p>
+    </CardContent>
+  </Card>
+</div>
+
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle>Notifications</CardTitle>
+    <CardDescription>You have 3 unread messages</CardDescription>
+    <CardAction>
+      <Button variant="outline" size="sm">View All</Button>
+    </CardAction>
+  </CardHeader>
+  <CardContent>
+    <p>Recent activity will appear here.</p>
+  </CardContent>
+</Card>
+```
+
+## Notebook Examples
+
+<div className="my-4">
+  <Card className="w-full max-w-md">
+    <CardHeader>
+      <CardTitle>Cell Output</CardTitle>
+      <CardDescription>Execution completed in 0.42s</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <pre className="bg-muted p-2 rounded text-sm">{'{"result": 42}'}</pre>
+    </CardContent>
+  </Card>
+</div>
+
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle>Cell Output</CardTitle>
+    <CardDescription>Execution completed in 0.42s</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <pre className="bg-muted p-2 rounded text-sm">{'{"result": 42}'}</pre>
+  </CardContent>
+</Card>
+```
+
+## Props
+
+### Card
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### CardHeader
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### CardTitle
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### CardDescription
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### CardContent
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### CardFooter
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### CardAction
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "UI",
-  "pages": ["badge", "button", "input", "kbd", "spinner"]
+  "pages": ["badge", "button", "card", "input", "kbd", "popover", "spinner", "tooltip"]
 }

--- a/content/docs/ui/popover.mdx
+++ b/content/docs/ui/popover.mdx
@@ -1,0 +1,223 @@
+---
+title: Popover
+description: A floating panel for displaying rich content triggered by a button or element
+icon: MessageSquare
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverTitle, PopoverDescription } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+
+<div className="my-8">
+  <Popover>
+    <PopoverTrigger asChild>
+      <Button variant="outline">Open Popover</Button>
+    </PopoverTrigger>
+    <PopoverContent>
+      <PopoverHeader>
+        <PopoverTitle>Popover Title</PopoverTitle>
+        <PopoverDescription>This is a popover with rich content.</PopoverDescription>
+      </PopoverHeader>
+    </PopoverContent>
+  </Popover>
+</div>
+
+A floating overlay panel that displays rich content when triggered. Built on Radix UI Popover for accessible, keyboard-navigable interactions.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add popover
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from [shadcn/ui popover](https://ui.shadcn.com/docs/components/popover).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+
+export function Example() {
+  return (
+    <Popover>
+      <PopoverTrigger>Open</PopoverTrigger>
+      <PopoverContent>Content goes here.</PopoverContent>
+    </Popover>
+  )
+}
+```
+
+## Examples
+
+### Basic Popover
+
+<div className="my-4">
+  <Popover>
+    <PopoverTrigger asChild>
+      <Button variant="outline">Click me</Button>
+    </PopoverTrigger>
+    <PopoverContent>
+      <p className="text-sm">Simple popover content.</p>
+    </PopoverContent>
+  </Popover>
+</div>
+
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="outline">Click me</Button>
+  </PopoverTrigger>
+  <PopoverContent>
+    <p className="text-sm">Simple popover content.</p>
+  </PopoverContent>
+</Popover>
+```
+
+### With Header
+
+<div className="my-4">
+  <Popover>
+    <PopoverTrigger asChild>
+      <Button>Settings</Button>
+    </PopoverTrigger>
+    <PopoverContent className="w-80">
+      <PopoverHeader>
+        <PopoverTitle>Settings</PopoverTitle>
+        <PopoverDescription>Configure your preferences here.</PopoverDescription>
+      </PopoverHeader>
+      <div className="grid gap-2 pt-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm">Notifications</span>
+          <Button variant="outline" size="sm">Toggle</Button>
+        </div>
+      </div>
+    </PopoverContent>
+  </Popover>
+</div>
+
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button>Settings</Button>
+  </PopoverTrigger>
+  <PopoverContent className="w-80">
+    <PopoverHeader>
+      <PopoverTitle>Settings</PopoverTitle>
+      <PopoverDescription>Configure your preferences here.</PopoverDescription>
+    </PopoverHeader>
+    <div className="grid gap-2 pt-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm">Notifications</span>
+        <Button variant="outline" size="sm">Toggle</Button>
+      </div>
+    </div>
+  </PopoverContent>
+</Popover>
+```
+
+## Notebook Examples
+
+<div className="my-4">
+  <Popover>
+    <PopoverTrigger asChild>
+      <Button variant="secondary" size="sm">Cell Info</Button>
+    </PopoverTrigger>
+    <PopoverContent className="w-64">
+      <PopoverHeader>
+        <PopoverTitle>Cell Metadata</PopoverTitle>
+        <PopoverDescription>Execution details</PopoverDescription>
+      </PopoverHeader>
+      <div className="grid gap-1 pt-2 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Duration:</span>
+          <span>0.42s</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Kernel:</span>
+          <span>Python 3.11</span>
+        </div>
+      </div>
+    </PopoverContent>
+  </Popover>
+</div>
+
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="secondary" size="sm">Cell Info</Button>
+  </PopoverTrigger>
+  <PopoverContent className="w-64">
+    <PopoverHeader>
+      <PopoverTitle>Cell Metadata</PopoverTitle>
+      <PopoverDescription>Execution details</PopoverDescription>
+    </PopoverHeader>
+    <div className="grid gap-1 pt-2 text-sm">
+      <div className="flex justify-between">
+        <span className="text-muted-foreground">Duration:</span>
+        <span>0.42s</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-muted-foreground">Kernel:</span>
+        <span>Python 3.11</span>
+      </div>
+    </div>
+  </PopoverContent>
+</Popover>
+```
+
+## Props
+
+### Popover
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `open` | `boolean` | — | Controlled open state |
+| `defaultOpen` | `boolean` | `false` | Default open state |
+| `onOpenChange` | `(open: boolean) => void` | — | Callback when open state changes |
+| `modal` | `boolean` | `false` | Whether to render as modal |
+
+### PopoverTrigger
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `asChild` | `boolean` | `false` | Render as child element using Radix Slot |
+| `...props` | `ButtonHTMLAttributes` | — | All standard button attributes |
+
+### PopoverContent
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `align` | `"start" \| "center" \| "end"` | `"center"` | Alignment relative to trigger |
+| `sideOffset` | `number` | `4` | Distance from trigger in pixels |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `PopoverPrimitive.ContentProps` | — | All Radix Popover Content props |
+
+### PopoverHeader
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### PopoverTitle
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLHeadingElement>` | — | All standard h2 attributes |
+
+### PopoverDescription
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLParagraphElement>` | — | All standard p attributes |

--- a/content/docs/ui/tooltip.mdx
+++ b/content/docs/ui/tooltip.mdx
@@ -1,0 +1,203 @@
+---
+title: Tooltip
+description: A brief text label that appears on hover to provide additional context
+icon: Info
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { Button } from '@/components/ui/button';
+
+<div className="my-8">
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="outline">Hover me</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>This is a tooltip</p>
+    </TooltipContent>
+  </Tooltip>
+</div>
+
+A lightweight text popup that appears when hovering over an element. Built on Radix UI Tooltip for accessible, keyboard-friendly interactions.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add tooltip
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from [shadcn/ui tooltip](https://ui.shadcn.com/docs/components/tooltip).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
+
+export function Example() {
+  return (
+    <Tooltip>
+      <TooltipTrigger>Hover</TooltipTrigger>
+      <TooltipContent>
+        <p>Tooltip text</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+```
+
+## Examples
+
+### Basic Tooltip
+
+<div className="my-4">
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="outline">Hover</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>Add to library</p>
+    </TooltipContent>
+  </Tooltip>
+</div>
+
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button variant="outline">Hover</Button>
+  </TooltipTrigger>
+  <TooltipContent>
+    <p>Add to library</p>
+  </TooltipContent>
+</Tooltip>
+```
+
+### On Icon Button
+
+<div className="my-4">
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="ghost" size="sm">?</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>Click for help</p>
+    </TooltipContent>
+  </Tooltip>
+</div>
+
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button variant="ghost" size="sm">?</Button>
+  </TooltipTrigger>
+  <TooltipContent>
+    <p>Click for help</p>
+  </TooltipContent>
+</Tooltip>
+```
+
+### Multiple Tooltips with Provider
+
+When using multiple tooltips, wrap them in a single `TooltipProvider` to share delay settings:
+
+```tsx
+import { TooltipProvider } from "@/components/ui/tooltip"
+
+export function Example() {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger>First</TooltipTrigger>
+        <TooltipContent>First tooltip</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger>Second</TooltipTrigger>
+        <TooltipContent>Second tooltip</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+```
+
+## Notebook Examples
+
+<div className="my-4 flex gap-2">
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="outline" size="sm">Run</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>Execute cell (Shift+Enter)</p>
+    </TooltipContent>
+  </Tooltip>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="outline" size="sm">Stop</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>Interrupt kernel</p>
+    </TooltipContent>
+  </Tooltip>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="outline" size="sm">Restart</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>Restart kernel</p>
+    </TooltipContent>
+  </Tooltip>
+</div>
+
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button variant="outline" size="sm">Run</Button>
+  </TooltipTrigger>
+  <TooltipContent>
+    <p>Execute cell (Shift+Enter)</p>
+  </TooltipContent>
+</Tooltip>
+```
+
+## Props
+
+### Tooltip
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `open` | `boolean` | — | Controlled open state |
+| `defaultOpen` | `boolean` | `false` | Default open state |
+| `onOpenChange` | `(open: boolean) => void` | — | Callback when open state changes |
+| `delayDuration` | `number` | `0` | Delay before showing (ms) |
+
+### TooltipTrigger
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `asChild` | `boolean` | `false` | Render as child element using Radix Slot |
+| `...props` | `ButtonHTMLAttributes` | — | All standard button attributes |
+
+### TooltipContent
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `sideOffset` | `number` | `0` | Distance from trigger in pixels |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `TooltipPrimitive.ContentProps` | — | All Radix Tooltip Content props |
+
+### TooltipProvider
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `delayDuration` | `number` | `0` | Default delay for all tooltips (ms) |
+| `skipDelayDuration` | `number` | `300` | Skip delay when moving between tooltips (ms) |
+| `disableHoverableContent` | `boolean` | `false` | Prevent tooltip from staying open when hovering content |


### PR DESCRIPTION
## Summary

- Add Card, Popover, and Tooltip components via shadcn CLI
- Add MDX documentation with interactive examples for each component
- Update navigation in meta.json

## Test plan

- [x] Verify `pnpm run types:check` passes
- [x] Check Card documentation renders at `/docs/ui/card`
- [x] Check Popover documentation renders at `/docs/ui/popover`
- [x] Check Tooltip documentation renders at `/docs/ui/tooltip`
- [x] Verify interactive examples work in docs

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)