### PR TITLE
Add ExecutionStatus component

### DIFF
--- a/components/notebook/cell/ExecutionStatus.tsx
+++ b/components/notebook/cell/ExecutionStatus.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+
+interface ExecutionStatusProps {
+  executionState: string;
+}
+
+export const ExecutionStatus: React.FC<ExecutionStatusProps> = ({
+  executionState,
+}) => {
+  switch (executionState) {
+    case "idle":
+      return null;
+    case "queued":
+      return (
+        <Badge variant="secondary" className="h-5 text-xs">
+          Queued
+        </Badge>
+      );
+    case "running":
+      return (
+        <Badge
+          variant="outline"
+          className="h-5 border-blue-200 bg-blue-50 text-xs text-blue-700"
+        >
+          <div className="mr-1 h-2 w-2 animate-spin rounded-full border border-blue-600 border-t-transparent"></div>
+          Running
+        </Badge>
+      );
+    case "error":
+      return (
+        <Badge
+          variant="outline"
+          className="h-5 border-red-200 bg-red-50 text-xs text-red-700"
+        >
+          Error
+        </Badge>
+      );
+    default:
+      return null;
+  }
+};

--- a/content/docs/cell/execution-status.mdx
+++ b/content/docs/cell/execution-status.mdx
@@ -1,0 +1,98 @@
+---
+title: ExecutionStatus
+description: A badge component that displays the execution state of a notebook cell
+icon: Play
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { ExecutionStatus } from '@/components/notebook/cell/ExecutionStatus';
+
+<div className="my-8 flex flex-wrap gap-4">
+  <ExecutionStatus executionState="idle" />
+  <ExecutionStatus executionState="queued" />
+  <ExecutionStatus executionState="running" />
+  <ExecutionStatus executionState="error" />
+</div>
+
+A cell primitive that displays the current execution state of a notebook cell. Returns appropriate badges for queued, running, and error states, or nothing for idle.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://elements.nteract.io/r/execution-status.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from [nteract/elements](https://github.com/nteract/elements/blob/main/components/notebook/cell/ExecutionStatus.tsx).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { ExecutionStatus } from "@/components/notebook/cell/ExecutionStatus"
+
+export function CellHeader() {
+  return (
+    <div className="flex items-center gap-2">
+      <span>[1]:</span>
+      <ExecutionStatus executionState="running" />
+    </div>
+  )
+}
+```
+
+## States
+
+### Idle
+
+Returns `null` - no badge is displayed when the cell is idle.
+
+<div className="my-4 flex gap-4 items-center">
+  <span className="text-muted-foreground text-sm">No badge shown:</span>
+  <ExecutionStatus executionState="idle" />
+</div>
+
+```tsx
+<ExecutionStatus executionState="idle" />
+```
+
+### Queued
+
+<div className="my-4 flex gap-4">
+  <ExecutionStatus executionState="queued" />
+</div>
+
+```tsx
+<ExecutionStatus executionState="queued" />
+```
+
+### Running
+
+Displays a spinning indicator alongside the "Running" text.
+
+<div className="my-4 flex gap-4">
+  <ExecutionStatus executionState="running" />
+</div>
+
+```tsx
+<ExecutionStatus executionState="running" />
+```
+
+### Error
+
+<div className="my-4 flex gap-4">
+  <ExecutionStatus executionState="error" />
+</div>
+
+```tsx
+<ExecutionStatus executionState="error" />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `executionState` | `string` | — | The execution state: `"idle"`, `"queued"`, `"running"`, or `"error"` |

--- a/content/docs/cell/meta.json
+++ b/content/docs/cell/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Cell",
+  "pages": ["execution-status"]
+}

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -5,6 +5,8 @@
     "index",
     "---UI---",
     "...ui",
+    "---Cell---",
+    "...cell",
     "---Outputs---",
     "...outputs"
   ]

--- a/registry.json
+++ b/registry.json
@@ -131,6 +131,19 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "execution-status",
+      "type": "registry:component",
+      "title": "ExecutionStatus",
+      "description": "A badge component that displays the execution state of a notebook cell. Shows queued, running, or error states.",
+      "registryDependencies": ["badge"],
+      "files": [
+        {
+          "path": "components/notebook/cell/ExecutionStatus.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add ExecutionStatus cell primitive from runtimed/intheloop
- Add MDX documentation showing all states (idle, queued, running, error)
- Add to registry.json with badge dependency
- Create new Cell section in docs navigation

## Test plan
- [x] Verify `pnpm run types:check` passes
- [x] Verify docs render correctly at `/docs/cell/execution-status`
- [x] Verify all 4 states display correctly in live examples

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)