### PR TITLE
Add CellTypeButton component

### DIFF
--- a/components/notebook/cell/CellTypeButton.tsx
+++ b/components/notebook/cell/CellTypeButton.tsx
@@ -1,0 +1,88 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Bot, Code, Database, FileText, Plus } from "lucide-react";
+import { type ComponentProps } from "react";
+
+/** Supported cell types for notebook interfaces */
+export type CellType = "code" | "markdown" | "sql" | "ai";
+
+// Colocated cell type color styles that won't be affected by shadcn updates
+export const cellTypeStyles = {
+  code: "border-gray-300 focus-visible:border-gray-500 text-gray-600 hover:bg-gray-50 hover:text-gray-600 focus:bg-gray-50 focus-visible:ring-gray-100",
+  markdown:
+    "border-yellow-300 focus-visible:border-yellow-500 text-yellow-600 hover:bg-yellow-50 hover:text-yellow-600 focus:bg-yellow-50 focus-visible:ring-yellow-100",
+  sql: "border-blue-300 focus-visible:border-blue-500 text-blue-600 hover:bg-blue-50 hover:text-blue-600 focus:bg-blue-50 focus-visible:ring-blue-100",
+  ai: "border-purple-300 focus-visible:border-purple-500 text-purple-600 hover:bg-purple-50 hover:text-purple-600 focus:bg-purple-50 focus-visible:ring-purple-100",
+};
+
+interface CellTypeButtonProps
+  extends Omit<ComponentProps<typeof Button>, "children"> {
+  cellType: CellType;
+  showIcon?: boolean;
+  showPlus?: boolean;
+  label?: string;
+}
+
+export function CellTypeButton({
+  cellType,
+  showIcon = true,
+  showPlus = false,
+  label,
+  className,
+  ...props
+}: CellTypeButtonProps) {
+  const icons = {
+    code: Code,
+    markdown: FileText,
+    sql: Database,
+    ai: Bot,
+  };
+
+  const defaultLabels = {
+    code: "Code",
+    markdown: "Markdown",
+    sql: "SQL",
+    ai: "AI",
+  };
+
+  const Icon = icons[cellType];
+
+  return (
+    <Button
+      variant="outline"
+      className={cn(
+        cellTypeStyles[cellType],
+        "flex items-center gap-1.5",
+        className
+      )}
+      {...props}
+    >
+      {showPlus && (
+        <Plus className={props.size === "lg" ? "h-4 w-4" : "h-3 w-3"} />
+      )}
+      {showIcon && (
+        <Icon className={props.size === "lg" ? "h-4 w-4" : "h-3 w-3"} />
+      )}
+      {label || defaultLabels[cellType]}
+    </Button>
+  );
+}
+
+// Convenience components for specific cell types
+export function CodeCellButton(props: Omit<CellTypeButtonProps, "cellType">) {
+  return <CellTypeButton cellType="code" {...props} />;
+}
+
+export function MarkdownCellButton(
+  props: Omit<CellTypeButtonProps, "cellType">
+) {
+  return <CellTypeButton cellType="markdown" {...props} />;
+}
+
+export function SqlCellButton(props: Omit<CellTypeButtonProps, "cellType">) {
+  return <CellTypeButton cellType="sql" {...props} />;
+}
+
+export function AiCellButton(props: Omit<CellTypeButtonProps, "cellType">) {
+  return <CellTypeButton cellType="ai" {...props} />;
+}

--- a/content/docs/cell/cell-type-button.mdx
+++ b/content/docs/cell/cell-type-button.mdx
@@ -1,0 +1,197 @@
+---
+title: CellTypeButton
+description: Styled buttons for different notebook cell types with color coding
+icon: SquareStack
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { CellTypeButton, CodeCellButton, MarkdownCellButton, SqlCellButton, AiCellButton } from '@/components/notebook/cell/CellTypeButton';
+
+<div className="my-8 flex flex-wrap gap-4">
+  <CodeCellButton />
+  <MarkdownCellButton />
+  <SqlCellButton />
+  <AiCellButton />
+</div>
+
+Styled buttons for different notebook cell types. Each cell type has a distinct color scheme for visual differentiation. Includes convenience components for each cell type.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://elements.nteract.io/r/cell-type-button.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy the component from [nteract/elements](https://github.com/nteract/elements/blob/main/components/notebook/cell/CellTypeButton.tsx).
+
+    Requires the `Button` component from shadcn/ui.
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { CellTypeButton, CodeCellButton, MarkdownCellButton } from "@/components/notebook/cell/CellTypeButton"
+
+export function Example() {
+  return (
+    <div className="flex gap-2">
+      <CellTypeButton cellType="code" />
+      <CodeCellButton />
+      <MarkdownCellButton />
+    </div>
+  )
+}
+```
+
+## All Cell Types
+
+Each cell type has a distinct color scheme:
+
+<div className="my-4 flex flex-wrap gap-4">
+  <CellTypeButton cellType="code" />
+  <CellTypeButton cellType="markdown" />
+  <CellTypeButton cellType="sql" />
+  <CellTypeButton cellType="ai" />
+</div>
+
+```tsx
+<CellTypeButton cellType="code" />     // Gray
+<CellTypeButton cellType="markdown" /> // Yellow
+<CellTypeButton cellType="sql" />      // Blue
+<CellTypeButton cellType="ai" />       // Purple
+```
+
+## Convenience Components
+
+Pre-configured components for each cell type:
+
+### CodeCellButton
+
+<div className="my-4">
+  <CodeCellButton />
+</div>
+
+```tsx
+<CodeCellButton />
+```
+
+### MarkdownCellButton
+
+<div className="my-4">
+  <MarkdownCellButton />
+</div>
+
+```tsx
+<MarkdownCellButton />
+```
+
+### SqlCellButton
+
+<div className="my-4">
+  <SqlCellButton />
+</div>
+
+```tsx
+<SqlCellButton />
+```
+
+### AiCellButton
+
+<div className="my-4">
+  <AiCellButton />
+</div>
+
+```tsx
+<AiCellButton />
+```
+
+## With Plus Icon
+
+Show a plus icon for "add cell" actions:
+
+<div className="my-4 flex flex-wrap gap-4">
+  <CodeCellButton showPlus />
+  <MarkdownCellButton showPlus />
+  <SqlCellButton showPlus />
+  <AiCellButton showPlus />
+</div>
+
+```tsx
+<CodeCellButton showPlus />
+<MarkdownCellButton showPlus />
+```
+
+## Without Icon
+
+Hide the cell type icon:
+
+<div className="my-4 flex flex-wrap gap-4">
+  <CodeCellButton showIcon={false} />
+  <MarkdownCellButton showIcon={false} />
+</div>
+
+```tsx
+<CodeCellButton showIcon={false} />
+<MarkdownCellButton showIcon={false} />
+```
+
+## Custom Labels
+
+Override the default label:
+
+<div className="my-4 flex flex-wrap gap-4">
+  <CellTypeButton cellType="code" label="Python" />
+  <CellTypeButton cellType="ai" label="GPT-4" />
+</div>
+
+```tsx
+<CellTypeButton cellType="code" label="Python" />
+<CellTypeButton cellType="ai" label="GPT-4" />
+```
+
+## Sizes
+
+Supports all Button sizes:
+
+<div className="my-4 flex flex-wrap items-center gap-4">
+  <CodeCellButton size="xs" />
+  <CodeCellButton size="sm" />
+  <CodeCellButton size="default" />
+  <CodeCellButton size="lg" />
+</div>
+
+```tsx
+<CodeCellButton size="xs" />
+<CodeCellButton size="sm" />
+<CodeCellButton size="default" />
+<CodeCellButton size="lg" />
+```
+
+## Props
+
+### CellTypeButton
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cellType` | `"code" \| "markdown" \| "sql" \| "ai"` | Required | The type of cell |
+| `showIcon` | `boolean` | `true` | Show the cell type icon |
+| `showPlus` | `boolean` | `false` | Show a plus icon (for add actions) |
+| `label` | `string` | Cell type name | Custom button label |
+| `size` | `"default" \| "xs" \| "sm" \| "lg"` | `"default"` | Button size |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `ButtonProps` | — | All standard Button props |
+
+### Convenience Components
+
+`CodeCellButton`, `MarkdownCellButton`, `SqlCellButton`, and `AiCellButton` accept all props except `cellType`.
+
+## Exported Types
+
+```tsx
+export type CellType = "code" | "markdown" | "sql" | "ai";
+export const cellTypeStyles: Record<CellType, string>;
+```

--- a/content/docs/cell/meta.json
+++ b/content/docs/cell/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Cell",
-  "pages": ["execution-status"]
+  "pages": ["cell-type-button", "execution-status"]
 }

--- a/registry.json
+++ b/registry.json
@@ -133,6 +133,20 @@
       ]
     },
     {
+      "name": "cell-type-button",
+      "type": "registry:component",
+      "title": "CellTypeButton",
+      "description": "Styled buttons for different notebook cell types with color coding. Includes CodeCellButton, MarkdownCellButton, SqlCellButton, and AiCellButton convenience components.",
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "components/notebook/cell/CellTypeButton.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
       "name": "execution-status",
       "type": "registry:component",
       "title": "ExecutionStatus",


### PR DESCRIPTION
## Summary
- Add CellTypeButton with color-coded styles for code, markdown, sql, and ai cell types
- Include convenience components (CodeCellButton, MarkdownCellButton, SqlCellButton, AiCellButton)
- Add comprehensive MDX documentation with all variants and examples

Replaces the schema import with a local CellType type and updates imports to use project utilities.

Closes #17