### PR TITLE
Add RuntimeHealthIndicator component

### DIFF
--- a/app/_components/RuntimeHealthIndicatorDemo.tsx
+++ b/app/_components/RuntimeHealthIndicatorDemo.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RuntimeHealthIndicator } from "@/registry/cell/RuntimeHealthIndicator";
+import type { ComponentProps } from "react";
+
+type RuntimeHealthIndicatorDemoProps = Omit<
+  ComponentProps<typeof RuntimeHealthIndicator>,
+  "onClick"
+> & {
+  interactive?: boolean;
+};
+
+export function RuntimeHealthIndicatorDemo({
+  interactive = false,
+  ...props
+}: RuntimeHealthIndicatorDemoProps) {
+  return (
+    <RuntimeHealthIndicator
+      onClick={interactive ? () => {} : undefined}
+      {...props}
+    />
+  );
+}

--- a/content/docs/cell/meta.json
+++ b/content/docs/cell/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Cell",
-  "pages": ["cell-type-button", "execution-status", "play-button"]
+  "pages": ["cell-type-button", "execution-status", "play-button", "runtime-health-indicator"]
 }

--- a/content/docs/cell/runtime-health-indicator.mdx
+++ b/content/docs/cell/runtime-health-indicator.mdx
@@ -1,0 +1,139 @@
+---
+title: RuntimeHealthIndicator
+description: A visual indicator for kernel connection status in notebook interfaces
+icon: Circle
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { RuntimeHealthIndicatorDemo } from '@/app/_components/RuntimeHealthIndicatorDemo';
+
+<div className="my-8 flex gap-4 items-center">
+  <RuntimeHealthIndicatorDemo status="idle" kernelName="Python 3" interactive />
+  <RuntimeHealthIndicatorDemo status="busy" kernelName="Python 3" interactive />
+  <RuntimeHealthIndicatorDemo status="connecting" interactive />
+  <RuntimeHealthIndicatorDemo status="disconnected" interactive />
+</div>
+
+A component that displays kernel connection status with color-coded indicators. Shows one of four states: idle (green), busy (amber), connecting (blue), or disconnected (red). Optionally displays the kernel name and can function as a clickable button.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://nteract-elements.vercel.app/r/runtime-health-indicator.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy from [nteract/elements](https://github.com/nteract/elements/blob/main/registry/cell/RuntimeHealthIndicator.tsx).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { RuntimeHealthIndicator } from "@/registry/cell/RuntimeHealthIndicator"
+
+export function NotebookToolbar() {
+  return (
+    <RuntimeHealthIndicator
+      status="idle"
+      kernelName="Python 3"
+      onClick={() => openKernelSelector()}
+    />
+  )
+}
+```
+
+## Examples
+
+### Status Variants
+
+<div className="my-4 flex gap-4 items-center">
+  <RuntimeHealthIndicatorDemo status="idle" showStatus />
+  <RuntimeHealthIndicatorDemo status="busy" showStatus />
+  <RuntimeHealthIndicatorDemo status="connecting" showStatus />
+  <RuntimeHealthIndicatorDemo status="disconnected" showStatus />
+</div>
+
+```tsx
+<RuntimeHealthIndicator status="idle" showStatus />
+<RuntimeHealthIndicator status="busy" showStatus />
+<RuntimeHealthIndicator status="connecting" showStatus />
+<RuntimeHealthIndicator status="disconnected" showStatus />
+```
+
+### With Kernel Name
+
+<div className="my-4 flex gap-4 items-center">
+  <RuntimeHealthIndicatorDemo status="idle" kernelName="Python 3" interactive />
+  <RuntimeHealthIndicatorDemo status="busy" kernelName="Julia 1.10" interactive />
+  <RuntimeHealthIndicatorDemo status="idle" kernelName="R" interactive />
+</div>
+
+```tsx
+<RuntimeHealthIndicator status="idle" kernelName="Python 3" onClick={handleClick} />
+<RuntimeHealthIndicator status="busy" kernelName="Julia 1.10" onClick={handleClick} />
+<RuntimeHealthIndicator status="idle" kernelName="R" onClick={handleClick} />
+```
+
+### Indicator Only
+
+<div className="my-4 flex gap-4 items-center">
+  <RuntimeHealthIndicatorDemo status="idle" />
+  <RuntimeHealthIndicatorDemo status="busy" />
+  <RuntimeHealthIndicatorDemo status="connecting" />
+  <RuntimeHealthIndicatorDemo status="disconnected" />
+</div>
+
+```tsx
+<RuntimeHealthIndicator status="idle" />
+<RuntimeHealthIndicator status="busy" />
+<RuntimeHealthIndicator status="connecting" />
+<RuntimeHealthIndicator status="disconnected" />
+```
+
+### Full Display
+
+<div className="my-4">
+  <RuntimeHealthIndicatorDemo status="idle" kernelName="Python 3" showStatus interactive />
+</div>
+
+```tsx
+<RuntimeHealthIndicator
+  status="idle"
+  kernelName="Python 3"
+  showStatus
+  onClick={() => openKernelSelector()}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `status` | `"idle" \| "busy" \| "disconnected" \| "connecting"` | — | Current kernel connection status |
+| `kernelName` | `string` | — | Name of the kernel to display |
+| `onClick` | `() => void` | — | Callback when clicked (renders as button when provided) |
+| `showStatus` | `boolean` | `false` | Whether to show status text |
+| `className` | `string` | — | Additional CSS classes |
+
+## Exports
+
+The component also exports utility functions for customization:
+
+```tsx
+import {
+  RuntimeHealthIndicator,
+  getStatusColor,
+  getStatusText,
+  getStatusTextColor,
+  type RuntimeStatus
+} from "@/registry/cell/RuntimeHealthIndicator"
+
+// Get the Tailwind color class for a status
+getStatusColor("idle") // "text-green-500"
+
+// Get the display text for a status
+getStatusText("connecting") // "Connecting..."
+```

--- a/registry.json
+++ b/registry.json
@@ -260,6 +260,19 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "runtime-health-indicator",
+      "type": "registry:component",
+      "title": "RuntimeHealthIndicator",
+      "description": "A visual indicator for kernel connection status. Shows idle, busy, connecting, or disconnected states with color-coded dots. Can display kernel name and optionally function as a button.",
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/cell/RuntimeHealthIndicator.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/registry/cell/RuntimeHealthIndicator.tsx
+++ b/registry/cell/RuntimeHealthIndicator.tsx
@@ -1,0 +1,105 @@
+import { cn } from "@/lib/utils";
+import { Circle, Terminal } from "lucide-react";
+import React from "react";
+
+export type RuntimeStatus = "idle" | "busy" | "disconnected" | "connecting";
+
+interface RuntimeHealthIndicatorProps {
+  status: RuntimeStatus;
+  kernelName?: string;
+  onClick?: () => void;
+  showStatus?: boolean;
+  className?: string;
+}
+
+export function getStatusColor(status: RuntimeStatus): string {
+  switch (status) {
+    case "idle":
+      return "text-green-500";
+    case "busy":
+      return "text-amber-500";
+    case "connecting":
+      return "text-blue-500";
+    case "disconnected":
+    default:
+      return "text-red-500";
+  }
+}
+
+export function getStatusText(status: RuntimeStatus): string {
+  switch (status) {
+    case "idle":
+      return "Connected";
+    case "busy":
+      return "Busy";
+    case "connecting":
+      return "Connecting...";
+    case "disconnected":
+    default:
+      return "Disconnected";
+  }
+}
+
+export function getStatusTextColor(status: RuntimeStatus): string {
+  switch (status) {
+    case "idle":
+      return "text-green-600";
+    case "busy":
+      return "text-amber-600";
+    case "connecting":
+      return "text-blue-600";
+    case "disconnected":
+    default:
+      return "text-red-600";
+  }
+}
+
+export const RuntimeHealthIndicator: React.FC<RuntimeHealthIndicatorProps> = ({
+  status,
+  kernelName,
+  onClick,
+  showStatus = false,
+  className,
+}) => {
+  const content = (
+    <>
+      {kernelName && (
+        <>
+          <Terminal className="h-3 w-3 sm:h-4 sm:w-4" />
+          <span className="hidden text-xs sm:block sm:text-sm">
+            {kernelName}
+          </span>
+        </>
+      )}
+      <Circle
+        className={cn("size-2 fill-current", getStatusColor(status))}
+      />
+      {showStatus && (
+        <span className={cn("text-xs", getStatusTextColor(status))}>
+          {getStatusText(status)}
+        </span>
+      )}
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "flex items-center gap-1 rounded-md border border-input bg-background px-2 py-1 text-sm transition-colors hover:bg-accent hover:text-accent-foreground sm:gap-2",
+          className
+        )}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-1 sm:gap-2", className)}>
+      {content}
+    </div>
+  );
+};


### PR DESCRIPTION
Adds a visual indicator for kernel connection status to show idle, busy, connecting, or disconnected states. The component can display the kernel name and optionally function as a clickable button for kernel selection. Includes comprehensive MDX documentation with interactive examples and Tailwind-based styling.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)