### PR TITLE
Update docs for Sprint 1 complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,11 +124,11 @@ Brief description paragraph.
 <Tabs items={['CLI', 'Manual']}>
   <Tab value="CLI">
     ```bash
-    npx shadcn@latest add component-name
+    npx shadcn@latest add https://nteract-elements.vercel.app/r/component-name.json
     ```
   </Tab>
   <Tab value="Manual">
-    Copy from [shadcn/ui](https://ui.shadcn.com/docs/components/component-name).
+    Copy from the [nteract/elements registry](https://github.com/nteract/elements/tree/main/registry/primitives).
   </Tab>
 </Tabs>
 
@@ -140,18 +140,6 @@ import { ComponentName } from "@/registry/primitives/component-name"
 export function Example() {
   return <ComponentName>Example</ComponentName>
 }
-```
-
-## Examples
-
-### Variant Name
-
-<div className="my-4">
-  <ComponentName variant="example">Example</ComponentName>
-</div>
-
-```tsx
-<ComponentName variant="example">Example</ComponentName>
 ```
 
 ## Props
@@ -180,24 +168,37 @@ export function Example() {
 
 ## Issue Status
 
-Component intake is tracked in issue #4.
+Component intake is tracked in issue #4. Cell primitives tracked in #8.
 
-### Completed
+### Sprint 1 Complete ✅
 
-- #5 — Button and Input ✅
+**UI Primitives (`registry/primitives/`):**
+- #5 — Button, Input ✅
 - #6 — Badge, Kbd, Spinner ✅
 - #7 — Card, Popover, Tooltip ✅
 - #14 — DropdownMenu ✅
+
+**Cell Primitives (`registry/cell/`):**
+- #9 — RuntimeHealthIndicator ✅
 - #15 — PlayButton ✅
 - #16 — ExecutionStatus ✅
 - #17 — CellTypeButton ✅
+- #18 — CellControls ✅
+- #20 — CellHeader ✅
+
+**Infrastructure:**
+- #27 — Registry restructure ✅
 
 ### In Progress
 
-- #18 — CellControls (needs DropdownMenu ✅)
-- #19 — CellContainer (refactor needed)
-- #20 — CellHeader (refactor needed)
-- #9 — RuntimeHealthIndicator
+- #19 — CellContainer (with composition documentation)
+
+### Next Phase
+
+- #33 — Separator, Label, Textarea (shadcn primitives)
+- #34 — Tabs, Dialog, Sheet (shadcn primitives)
+- #35 — CellOutputArea (output wrapper component)
+- #36 — ExecutionCount (cell execution count display)
 
 ### Deferred
 

--- a/contributing/triage.md
+++ b/contributing/triage.md
@@ -34,16 +34,24 @@ Process for evaluating and importing components into nteract-elements.
 
 | Component | Description |
 |-----------|-------------|
+| `CellControls` | Action menu (delete, move, clear outputs) |
+| `CellHeader` | Slot-based header layout (left/right content) |
 | `CellTypeButton` | Code/Markdown/SQL/AI cell type buttons |
-| `ExecutionStatus` | Queued/Running/Error badges |
+| `ExecutionStatus` | Queued/Running/Error state badges |
 | `PlayButton` | Execute/interrupt button |
+| `RuntimeHealthIndicator` | Kernel connection status |
 
 ## Priority order for new components
 
-1. **Atomic primitives** — Separator, Label, Textarea
-2. **Layout utilities** — Sidebar, Tabs, Dialog, Sheet
-3. **Notebook primitives** — CellControls, CellContainer, CellHeader
-4. **Higher-level notebook UI** — RuntimeHealthIndicator
+### Next up
+
+1. **More shadcn primitives** — Separator, Label, Textarea (#33), Tabs, Dialog, Sheet (#34)
+2. **Cell composition** — CellContainer (#19), ExecutionCount (#36), CellOutputArea (#35)
+3. **Notebook-level components** — from intheloop (NotebookContent, NotebookSidebar)
+
+### Deferred
+
+- Dynamic registry API route (#10) — not blocking current work
 
 ## Directory structure
 
@@ -79,7 +87,7 @@ After adding via CLI:
 2. Add entry to `registry.json` with correct path
 3. Add MDX documentation under `content/docs/ui/<component>.mdx`
 4. Update `content/docs/ui/meta.json` to include the new component
-5. Open PR with commit message referencing the issue (e.g., `Closes #5`)
+5. Open PR with commit message referencing the issue (e.g., `Closes #33`)
 
 ### For notebook-specific components
 
@@ -115,25 +123,32 @@ For notebook-specific components not available via shadcn:
 
 ### `src/components/notebook/` — notebook-specific
 
-- `NotebookContent.tsx` — main notebook layout
-- `NotebookSidebar.tsx` — sidebar with panels
-- `NotebookTitle.tsx` — editable title
-- `NotebookLoadingScreen.tsx` — loading state
-- `RuntimeHealthIndicator.tsx` — kernel status indicator
-- `EmptyStateCellAdder.tsx` — empty notebook state
+| File | Status | Notes |
+|------|--------|-------|
+| `RuntimeHealthIndicator.tsx` | ✅ Done | #9 |
+| `NotebookContent.tsx` | Not started | Main notebook layout |
+| `NotebookSidebar.tsx` | Not started | Sidebar with panels |
+| `NotebookTitle.tsx` | Not started | Editable title |
+| `NotebookLoadingScreen.tsx` | Not started | Loading state |
+| `EmptyStateCellAdder.tsx` | Not started | Empty notebook state |
 
 ### `src/components/notebook/cell/` — cell components
 
-**Import as primitives (see #8 sub-issues):**
+**Completed:**
 
-| File | Size | Issue | Notes |
-|------|------|-------|-------|
-| `shared/PlayButton.tsx` | 1.8KB | #15 | ✅ Done |
-| `shared/ExecutionStatus.tsx` | 1KB | #16 | ✅ Done |
-| `CellTypeButtons.tsx` | 2.6KB | #17 | ✅ Done |
-| `shared/CellControls.tsx` | 5.4KB | #18 | Needs DropdownMenu |
-| `shared/CellContainer.tsx` | 3.2KB | #19 | Refactor — strip hooks |
-| `shared/CellHeader.tsx` | 1KB | #20 | Refactor — strip hooks |
+| File | Issue | Notes |
+|------|-------|-------|
+| `shared/PlayButton.tsx` | #15 ✅ | Execute/interrupt button |
+| `shared/ExecutionStatus.tsx` | #16 ✅ | State badges |
+| `CellTypeButtons.tsx` | #17 ✅ | Cell type buttons |
+| `shared/CellControls.tsx` | #18 ✅ | Action menu |
+| `shared/CellHeader.tsx` | #20 ✅ | Header layout |
+
+**In progress:**
+
+| File | Issue | Notes |
+|------|-------|-------|
+| `shared/CellContainer.tsx` | #19 | Focus/selection wrapper |
 
 **Do NOT import (too coupled):**
 
@@ -152,28 +167,10 @@ For notebook-specific components not available via shadcn:
 
 | Pattern | Found in | Replace with |
 |---------|----------|--------------|
-| `@runtimed/schema` types | CellContainer, CellTypeSelector | Local `CellType` interface |
-| `useDragDropCellSort` | CellContainer, CellHeader | Optional `onDragStart`, `onDrop` props |
-| `useFeatureFlag` | CellTypeSelector | `enabledCellTypes?: CellType[]` prop |
+| `@runtimed/schema` types | CellContainer | Local interface |
+| `useDragDropCellSort` | CellContainer, CellHeader | Optional callback props |
+| `useFeatureFlag` | CellTypeSelector | Props like `enabledCellTypes` |
 | `useAddCell` | CellAdder, CellBetweener | `onAddCell` callback prop |
-
-## Dependency graph for cell primitives
-
-```
-DropdownMenu (#14) ✅
-    └── CellControls (#18)
-
-Badge (#6) ✅
-    └── ExecutionStatus (#16) ✅
-
-Button (#5) ✅
-    └── CellTypeButton (#17) ✅
-
-No deps:
-    ├── PlayButton (#15) ✅
-    ├── CellContainer (#19) — refactor only
-    └── CellHeader (#20) — refactor only
-```
 
 ## Dependencies
 


### PR DESCRIPTION
Updates `contributing/triage.md` and `AGENTS.md` to reflect Sprint 1 completion.

## Sprint 1 Delivered

**UI Primitives (9):** badge, button, card, dropdown-menu, input, kbd, popover, spinner, tooltip

**Cell Components (6):** CellControls, CellHeader, CellTypeButton, ExecutionStatus, PlayButton, RuntimeHealthIndicator

**Infrastructure:** Registry restructure (`registry/primitives/`, `registry/cell/`, `registry/outputs/`)

## Next Phase Issues Created

- #33 — Separator, Label, Textarea
- #34 — Tabs, Dialog, Sheet
- #35 — CellOutputArea
- #36 — ExecutionCount

## Still In Progress

- #19 — CellContainer (agent working on composition docs)