### PR TITLE
Fix dark mode styling for cell components

### DIFF
--- a/registry/cell/CellTypeButton.tsx
+++ b/registry/cell/CellTypeButton.tsx
@@ -8,7 +8,7 @@ export type CellType = "code" | "markdown" | "sql" | "ai";
 
 // Colocated cell type color styles that won't be affected by shadcn updates
 export const cellTypeStyles = {
-  code: "border-gray-300 focus-visible:border-gray-500 text-gray-600 hover:bg-gray-50 hover:text-gray-600 focus:bg-gray-50 focus-visible:ring-gray-100",
+  code: "border-gray-300 dark:border-gray-500 focus-visible:border-gray-500 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-gray-600 focus:bg-gray-50 dark:focus:bg-gray-800 focus-visible:ring-gray-100 dark:focus-visible:ring-gray-700",
   markdown:
     "border-yellow-300 focus-visible:border-yellow-500 text-yellow-600 hover:bg-yellow-50 hover:text-yellow-600 focus:bg-yellow-50 focus-visible:ring-yellow-100",
   sql: "border-blue-300 focus-visible:border-blue-500 text-blue-600 hover:bg-blue-50 hover:text-blue-600 focus:bg-blue-50 focus-visible:ring-blue-100",

--- a/registry/cell/PlayButton.tsx
+++ b/registry/cell/PlayButton.tsx
@@ -35,7 +35,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
       onClick={isRunning ? onInterrupt : onExecute}
       disabled={isAutoLaunching}
       className={cn(
-        "hover:bg-muted/80 flex items-center justify-center rounded-sm bg-white p-1 transition-colors",
+        "hover:bg-muted/80 flex items-center justify-center rounded-sm bg-background p-1 transition-colors",
         isRunning
           ? "text-destructive hover:text-destructive shadow-destructive/20 animate-pulse drop-shadow-sm"
           : isFocused
@@ -56,7 +56,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
           className="size-4"
         />
       ) : (
-        <Play fill="white" className="size-4" />
+        <Play fill="currentColor" className="size-4" />
       )}
     </button>
   );


### PR DESCRIPTION
## Summary
- **PlayButton**: Replace hardcoded `bg-white` with `bg-background` and `fill="white"` with `fill="currentColor"` so the play icon is visible in dark mode
- **CellTypeButton**: Add dark mode variants for the code cell type (border, text, hover, focus styles)

Fixes #49

## Test plan
- [ ] Verify PlayButton shows visible play icon in dark mode
- [ ] Verify CellTypeButton "Code" variant has proper contrast in dark mode
- [ ] Confirm light mode styling is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)