### PR TITLE
Add CellTypeSelector component

### DIFF
--- a/app/components/CellTypeSelectorDemo.tsx
+++ b/app/components/CellTypeSelectorDemo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import { CellTypeSelector } from "@/registry/cell/CellTypeSelector";
+import type { CellType } from "@/registry/cell/CellTypeButton";
+
+export function CellTypeSelectorDemo() {
+  const [cellType, setCellType] = useState<CellType>("code");
+
+  return (
+    <CellTypeSelector currentType={cellType} onTypeChange={setCellType} />
+  );
+}
+
+export function CellTypeSelectorLimitedDemo() {
+  const [cellType, setCellType] = useState<CellType>("code");
+
+  return (
+    <CellTypeSelector
+      currentType={cellType}
+      onTypeChange={setCellType}
+      enabledTypes={["code", "markdown"]}
+    />
+  );
+}

--- a/content/docs/cell/cell-type-selector.mdx
+++ b/content/docs/cell/cell-type-selector.mdx
@@ -1,0 +1,97 @@
+---
+title: CellTypeSelector
+description: Dropdown selector for changing cell types in notebook interfaces
+icon: ListFilter
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { CellTypeSelectorDemo, CellTypeSelectorLimitedDemo } from '@/app/components/CellTypeSelectorDemo';
+
+<div className="my-8">
+  <CellTypeSelectorDemo />
+</div>
+
+A dropdown selector for changing cell types. Displays the current type with color-coded styling and allows users to switch between available types.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://nteract-elements.vercel.app/r/cell-type-selector.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy from the [nteract/elements registry](https://github.com/nteract/elements/tree/main/registry/cell/CellTypeSelector.tsx).
+
+    Requires the `Button`, `DropdownMenu`, and `CellTypeButton` components from the nteract registry.
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { CellTypeSelector } from "@/registry/cell/CellTypeSelector"
+
+export function Example() {
+  const [cellType, setCellType] = useState<CellType>("code")
+
+  return (
+    <CellTypeSelector
+      currentType={cellType}
+      onTypeChange={setCellType}
+    />
+  )
+}
+```
+
+## All Cell Types
+
+The selector shows all cell types by default:
+
+<div className="my-4">
+  <CellTypeSelectorDemo />
+</div>
+
+```tsx
+<CellTypeSelector
+  currentType="code"
+  onTypeChange={(type) => console.log(type)}
+/>
+```
+
+## Limited Types
+
+Restrict available types using the `enabledTypes` prop:
+
+<div className="my-4">
+  <CellTypeSelectorLimitedDemo />
+</div>
+
+```tsx
+<CellTypeSelector
+  currentType="code"
+  onTypeChange={(type) => console.log(type)}
+  enabledTypes={["code", "markdown"]}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `currentType` | `CellType` | Required | The currently selected cell type |
+| `onTypeChange` | `(type: CellType) => void` | Required | Callback when the type changes |
+| `enabledTypes` | `CellType[]` | All types | Types available in the dropdown |
+
+## Types
+
+```tsx
+type CellType = "code" | "markdown" | "sql" | "ai";
+
+interface CellTypeSelectorProps {
+  currentType: CellType;
+  onTypeChange: (type: CellType) => void;
+  enabledTypes?: CellType[];
+}
+```

--- a/content/docs/cell/meta.json
+++ b/content/docs/cell/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Cell",
-  "pages": ["cell-container", "cell-controls", "cell-header", "output-area", "cell-type-button", "execution-count", "execution-status", "play-button", "runtime-health-indicator"]
+  "pages": ["cell-container", "cell-controls", "cell-header", "output-area", "cell-type-button", "cell-type-selector", "execution-count", "execution-status", "play-button", "runtime-health-indicator"]
 }

--- a/registry.json
+++ b/registry.json
@@ -482,6 +482,20 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "cell-type-selector",
+      "type": "registry:component",
+      "title": "CellTypeSelector",
+      "description": "A dropdown selector for changing cell types in notebook interfaces. Supports filtering available types and displays the current type with color-coded styling.",
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button", "dropdown-menu", "cell-type-button"],
+      "files": [
+        {
+          "path": "registry/cell/CellTypeSelector.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/registry/cell/CellTypeSelector.tsx
+++ b/registry/cell/CellTypeSelector.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Bot, Code, Database, FileText, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/primitives/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/registry/primitives/dropdown-menu";
+import { type CellType, cellTypeStyles } from "@/registry/cell/CellTypeButton";
+
+const allCellTypes: CellType[] = ["code", "markdown", "sql", "ai"];
+
+const cellTypeIcons = {
+  code: Code,
+  markdown: FileText,
+  sql: Database,
+  ai: Bot,
+};
+
+const cellTypeLabels = {
+  code: "Code",
+  markdown: "Markdown",
+  sql: "SQL",
+  ai: "AI",
+};
+
+const cellTypeMenuItemStyles = {
+  code: "text-gray-500 dark:text-gray-400 [&_svg]:text-gray-500 dark:[&_svg]:text-gray-400 focus:bg-gray-100 dark:focus:bg-gray-800 focus:text-gray-700 dark:focus:text-gray-200 focus:[&_svg]:text-gray-700 dark:focus:[&_svg]:text-gray-200",
+  markdown:
+    "text-yellow-600/70 [&_svg]:text-yellow-600/70 focus:bg-yellow-50 dark:focus:bg-yellow-900/30 focus:text-yellow-600 dark:focus:text-yellow-500 focus:[&_svg]:text-yellow-600 dark:focus:[&_svg]:text-yellow-500",
+  sql: "text-blue-600/70 [&_svg]:text-blue-600/70 focus:bg-blue-50 dark:focus:bg-blue-900/30 focus:text-blue-600 dark:focus:text-blue-500 focus:[&_svg]:text-blue-600 dark:focus:[&_svg]:text-blue-500",
+  ai: "text-purple-600/70 [&_svg]:text-purple-600/70 focus:bg-purple-50 dark:focus:bg-purple-900/30 focus:text-purple-600 dark:focus:text-purple-500 focus:[&_svg]:text-purple-600 dark:focus:[&_svg]:text-purple-500",
+};
+
+interface CellTypeSelectorProps {
+  currentType: CellType;
+  onTypeChange: (type: CellType) => void;
+  enabledTypes?: CellType[];
+}
+
+export function CellTypeSelector({
+  currentType,
+  onTypeChange,
+  enabledTypes = allCellTypes,
+}: CellTypeSelectorProps) {
+  const Icon = cellTypeIcons[currentType];
+  const availableTypes = allCellTypes.filter((type) =>
+    enabledTypes.includes(type)
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(
+            cellTypeStyles[currentType],
+            "flex items-center gap-1.5"
+          )}
+        >
+          <Icon className="h-3 w-3" />
+          {cellTypeLabels[currentType]}
+          <ChevronDown className="h-3 w-3 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {availableTypes.map((type) => {
+          const TypeIcon = cellTypeIcons[type];
+          return (
+            <DropdownMenuItem
+              key={type}
+              onClick={() => onTypeChange(type)}
+              className={cn(
+                "flex items-center gap-2",
+                cellTypeMenuItemStyles[type],
+                type === currentType && "bg-accent"
+              )}
+            >
+              <TypeIcon className="h-4 w-4" />
+              {cellTypeLabels[type]}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `CellTypeSelector` component for changing cell types via dropdown
- Supports filtering available types with `enabledTypes` prop
- Uses color-coded styling from `CellTypeButton`
- Includes MDX documentation and demo components

## Test plan
- [ ] Verify dropdown opens and shows all cell types
- [ ] Test `enabledTypes` prop filters dropdown items
- [ ] Check type change callback fires correctly
- [ ] Verify styling matches current cell type

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)