### PR TITLE
Add Empty component

### DIFF
--- a/content/docs/ui/empty.mdx
+++ b/content/docs/ui/empty.mdx
@@ -1,0 +1,216 @@
+---
+title: Empty
+description: A container for empty states with slots for icon, title, description, and actions
+icon: BoxSelect
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Empty, EmptyIcon, EmptyTitle, EmptyDescription, EmptyActions } from '@/registry/primitives/empty';
+import { Button } from '@/registry/primitives/button';
+import { FileX, Inbox, Search } from 'lucide-react';
+
+<div className="my-8">
+  <Empty className="border rounded-lg">
+    <EmptyIcon>
+      <Inbox />
+    </EmptyIcon>
+    <EmptyTitle>No items yet</EmptyTitle>
+    <EmptyDescription>
+      Get started by creating your first item.
+    </EmptyDescription>
+    <EmptyActions>
+      <Button size="sm">Create Item</Button>
+    </EmptyActions>
+  </Empty>
+</div>
+
+A flexible empty state component for displaying placeholder content when there's no data to show. Perfect for empty lists, search results with no matches, or initial states.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://nteract-elements.vercel.app/r/empty.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy from the [nteract/elements registry](https://github.com/nteract/elements/tree/main/registry/primitives).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import {
+  Empty,
+  EmptyIcon,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyActions,
+} from "@/registry/primitives/empty"
+import { Inbox } from "lucide-react"
+
+export function Example() {
+  return (
+    <Empty>
+      <EmptyIcon>
+        <Inbox />
+      </EmptyIcon>
+      <EmptyTitle>No items</EmptyTitle>
+      <EmptyDescription>
+        There are no items to display.
+      </EmptyDescription>
+      <EmptyActions>
+        <Button>Add Item</Button>
+      </EmptyActions>
+    </Empty>
+  )
+}
+```
+
+## Examples
+
+### With Icon
+
+<div className="my-4">
+  <Empty className="border rounded-lg">
+    <EmptyIcon>
+      <FileX />
+    </EmptyIcon>
+    <EmptyTitle>No files found</EmptyTitle>
+  </Empty>
+</div>
+
+```tsx
+<Empty>
+  <EmptyIcon>
+    <FileX />
+  </EmptyIcon>
+  <EmptyTitle>No files found</EmptyTitle>
+</Empty>
+```
+
+### With Title and Description
+
+<div className="my-4">
+  <Empty className="border rounded-lg">
+    <EmptyIcon>
+      <Search />
+    </EmptyIcon>
+    <EmptyTitle>No results</EmptyTitle>
+    <EmptyDescription>
+      We couldn't find anything matching your search. Try adjusting your filters or search terms.
+    </EmptyDescription>
+  </Empty>
+</div>
+
+```tsx
+<Empty>
+  <EmptyIcon>
+    <Search />
+  </EmptyIcon>
+  <EmptyTitle>No results</EmptyTitle>
+  <EmptyDescription>
+    We couldn't find anything matching your search. Try adjusting your filters or search terms.
+  </EmptyDescription>
+</Empty>
+```
+
+### With Action Button
+
+<div className="my-4">
+  <Empty className="border rounded-lg">
+    <EmptyIcon>
+      <Inbox />
+    </EmptyIcon>
+    <EmptyTitle>No notebooks</EmptyTitle>
+    <EmptyDescription>
+      Create a new notebook to get started with your analysis.
+    </EmptyDescription>
+    <EmptyActions>
+      <Button size="sm">New Notebook</Button>
+    </EmptyActions>
+  </Empty>
+</div>
+
+```tsx
+<Empty>
+  <EmptyIcon>
+    <Inbox />
+  </EmptyIcon>
+  <EmptyTitle>No notebooks</EmptyTitle>
+  <EmptyDescription>
+    Create a new notebook to get started with your analysis.
+  </EmptyDescription>
+  <EmptyActions>
+    <Button size="sm">New Notebook</Button>
+  </EmptyActions>
+</Empty>
+```
+
+### Size Variants
+
+<div className="my-4 space-y-4">
+  <Empty size="sm" className="border rounded-lg">
+    <EmptyTitle>Small empty state</EmptyTitle>
+  </Empty>
+  <Empty size="default" className="border rounded-lg">
+    <EmptyTitle>Default empty state</EmptyTitle>
+  </Empty>
+  <Empty size="lg" className="border rounded-lg">
+    <EmptyTitle>Large empty state</EmptyTitle>
+  </Empty>
+</div>
+
+```tsx
+<Empty size="sm">
+  <EmptyTitle>Small empty state</EmptyTitle>
+</Empty>
+
+<Empty size="default">
+  <EmptyTitle>Default empty state</EmptyTitle>
+</Empty>
+
+<Empty size="lg">
+  <EmptyTitle>Large empty state</EmptyTitle>
+</Empty>
+```
+
+## Props
+
+### Empty
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `size` | `"sm" \| "default" \| "lg"` | `"default"` | Size variant for padding and spacing |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### EmptyIcon
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |
+
+### EmptyTitle
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLHeadingElement>` | — | All standard h3 attributes |
+
+### EmptyDescription
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLParagraphElement>` | — | All standard p attributes |
+
+### EmptyActions
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `className` | `string` | — | Additional CSS classes |
+| `...props` | `HTMLAttributes<HTMLDivElement>` | — | All standard div attributes |

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "UI",
-  "pages": ["avatar", "badge", "button", "card", "command", "dialog", "dropdown-menu", "hover-card", "input", "kbd", "label", "popover", "separator", "sheet", "spinner", "tabs", "textarea", "tooltip"]
+  "pages": ["avatar", "badge", "button", "card", "command", "dialog", "dropdown-menu", "empty", "hover-card", "input", "kbd", "label", "popover", "separator", "sheet", "spinner", "tabs", "textarea", "tooltip"]
 }

--- a/registry.json
+++ b/registry.json
@@ -455,6 +455,19 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "empty",
+      "type": "registry:ui",
+      "title": "Empty",
+      "description": "Empty state container with slots for icon, title, description, and actions.",
+      "dependencies": ["class-variance-authority"],
+      "files": [
+        {
+          "path": "registry/primitives/empty.tsx",
+          "type": "registry:ui"
+        }
+      ]
     }
   ]
 }

--- a/registry/primitives/empty.tsx
+++ b/registry/primitives/empty.tsx
@@ -1,0 +1,86 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const emptyVariants = cva(
+  "flex flex-col items-center justify-center text-center",
+  {
+    variants: {
+      size: {
+        sm: "gap-2 py-6",
+        default: "gap-3 py-8",
+        lg: "gap-4 py-12",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+)
+
+function Empty({
+  className,
+  size,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyVariants>) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(emptyVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyIcon({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-icon"
+      className={cn(
+        "flex items-center justify-center text-muted-foreground [&>svg]:size-10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"h3">) {
+  return (
+    <h3
+      data-slot="empty-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="empty-description"
+      className={cn("text-sm text-muted-foreground max-w-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-actions"
+      className={cn("flex items-center gap-2 mt-2", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyIcon,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyActions,
+  emptyVariants,
+}


### PR DESCRIPTION
## Summary
- Adds `Empty` component for displaying empty state containers
- Includes `EmptyIcon`, `EmptyTitle`, `EmptyDescription`, and `EmptyActions` sub-components
- Supports size variants: `sm`, `default`, `lg`
- Adds MDX documentation with examples

## Test plan
- [x] Run `pnpm run types:check` - passes
- [ ] Verify component renders in Storybook/docs

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)