### PR TITLE
Add ButtonGroup component

### DIFF
--- a/content/docs/ui/button-group.mdx
+++ b/content/docs/ui/button-group.mdx
@@ -1,0 +1,149 @@
+---
+title: ButtonGroup
+description: Group buttons together with merged borders
+icon: RectangleHorizontal
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Button } from '@/registry/primitives/button';
+import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText } from '@/registry/primitives/button-group';
+import { ChevronDown, Bold, Italic, Underline } from 'lucide-react';
+
+<div className="my-8">
+  <ButtonGroup>
+    <Button variant="outline">Run</Button>
+    <Button variant="outline">Stop</Button>
+    <Button variant="outline">Restart</Button>
+  </ButtonGroup>
+</div>
+
+Group buttons together with merged borders. Includes `ButtonGroupSeparator` for visual dividers and `ButtonGroupText` for label sections.
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://nteract-elements.vercel.app/r/button-group.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy from the [nteract/elements registry](https://github.com/nteract/elements/tree/main/registry/primitives).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText } from "@/registry/primitives/button-group"
+import { Button } from "@/registry/primitives/button"
+
+export function Example() {
+  return (
+    <ButtonGroup>
+      <Button variant="outline">Run</Button>
+      <Button variant="outline">Stop</Button>
+      <Button variant="outline">Restart</Button>
+    </ButtonGroup>
+  )
+}
+```
+
+## Examples
+
+### Basic
+
+<div className="my-4">
+  <ButtonGroup>
+    <Button variant="outline">Previous</Button>
+    <Button variant="outline">Next</Button>
+  </ButtonGroup>
+</div>
+
+```tsx
+<ButtonGroup>
+  <Button variant="outline">Previous</Button>
+  <Button variant="outline">Next</Button>
+</ButtonGroup>
+```
+
+### With Separator
+
+<div className="my-4">
+  <ButtonGroup>
+    <Button variant="outline"><Bold className="size-4" /></Button>
+    <Button variant="outline"><Italic className="size-4" /></Button>
+    <Button variant="outline"><Underline className="size-4" /></Button>
+    <ButtonGroupSeparator />
+    <Button variant="outline"><ChevronDown className="size-4" /></Button>
+  </ButtonGroup>
+</div>
+
+```tsx
+<ButtonGroup>
+  <Button variant="outline"><Bold /></Button>
+  <Button variant="outline"><Italic /></Button>
+  <Button variant="outline"><Underline /></Button>
+  <ButtonGroupSeparator />
+  <Button variant="outline"><ChevronDown /></Button>
+</ButtonGroup>
+```
+
+### With Text
+
+<div className="my-4">
+  <ButtonGroup>
+    <ButtonGroupText>Kernel</ButtonGroupText>
+    <Button variant="outline">Restart</Button>
+    <Button variant="outline">Interrupt</Button>
+  </ButtonGroup>
+</div>
+
+```tsx
+<ButtonGroup>
+  <ButtonGroupText>Kernel</ButtonGroupText>
+  <Button variant="outline">Restart</Button>
+  <Button variant="outline">Interrupt</Button>
+</ButtonGroup>
+```
+
+### Vertical Orientation
+
+<div className="my-4">
+  <ButtonGroup orientation="vertical">
+    <Button variant="outline">Top</Button>
+    <Button variant="outline">Middle</Button>
+    <Button variant="outline">Bottom</Button>
+  </ButtonGroup>
+</div>
+
+```tsx
+<ButtonGroup orientation="vertical">
+  <Button variant="outline">Top</Button>
+  <Button variant="outline">Middle</Button>
+  <Button variant="outline">Bottom</Button>
+</ButtonGroup>
+```
+
+## Props
+
+### ButtonGroup
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | The orientation of the button group |
+| `className` | `string` | — | Additional CSS classes |
+
+### ButtonGroupText
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `asChild` | `boolean` | `false` | Merge props onto child element |
+| `className` | `string` | — | Additional CSS classes |
+
+### ButtonGroupSeparator
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `orientation` | `"horizontal" \| "vertical"` | `"vertical"` | The orientation of the separator |
+| `className` | `string` | — | Additional CSS classes |

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "UI",
-  "pages": ["avatar", "badge", "button", "card", "command", "dialog", "dropdown-menu", "empty", "hover-card", "input", "kbd", "label", "popover", "separator", "sheet", "spinner", "tabs", "textarea", "tooltip"]
+  "pages": ["avatar", "badge", "button", "button-group", "card", "command", "dialog", "dropdown-menu", "empty", "hover-card", "input", "kbd", "label", "popover", "separator", "sheet", "spinner", "tabs", "textarea", "tooltip"]
 }

--- a/registry.json
+++ b/registry.json
@@ -133,6 +133,20 @@
       ]
     },
     {
+      "name": "button-group",
+      "type": "registry:ui",
+      "title": "ButtonGroup",
+      "description": "Group buttons together with merged borders. Includes ButtonGroupSeparator and ButtonGroupText.",
+      "dependencies": ["@radix-ui/react-slot", "class-variance-authority"],
+      "registryDependencies": ["separator"],
+      "files": [
+        {
+          "path": "registry/primitives/button-group.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "card",
       "type": "registry:ui",
       "title": "Card",

--- a/registry/primitives/button-group.tsx
+++ b/registry/primitives/button-group.tsx
@@ -1,0 +1,83 @@
+import { Slot } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Separator } from "@/registry/primitives/separator";
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+);
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "div";
+
+  return (
+    <Comp
+      className={cn(
+        "bg-muted flex items-center gap-2 rounded-md border px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+};


### PR DESCRIPTION
## Summary
- Import ButtonGroup component from intheloop to nteract/elements
- Includes ButtonGroupSeparator for visual dividers and ButtonGroupText for label sections
- Supports horizontal and vertical orientations with merged button borders

## Test plan
- [x] Run `pnpm run types:check` to verify the build passes
- [ ] Verify component renders correctly in documentation

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)