### PR TITLE
Add CollaboratorAvatars component

### DIFF
--- a/app/components/CollaboratorAvatarsDemo.tsx
+++ b/app/components/CollaboratorAvatarsDemo.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { CollaboratorAvatars } from "@/registry/cell/CollaboratorAvatars";
+
+const sampleUsers = [
+  {
+    id: "1",
+    name: "Alice Smith",
+    picture: "https://api.dicebear.com/7.x/avataaars/svg?seed=Alice",
+    color: "#e91e63",
+  },
+  {
+    id: "2",
+    name: "Bob Johnson",
+    color: "#2196f3",
+  },
+  {
+    id: "3",
+    name: "Carol Williams",
+    picture: "https://api.dicebear.com/7.x/avataaars/svg?seed=Carol",
+    color: "#4caf50",
+  },
+  {
+    id: "4",
+    name: "David Brown",
+    color: "#ff9800",
+  },
+  {
+    id: "5",
+    name: "Eve Davis",
+    picture: "https://api.dicebear.com/7.x/avataaars/svg?seed=Eve",
+    color: "#9c27b0",
+  },
+];
+
+interface CollaboratorAvatarsDemoProps {
+  currentUserId?: string;
+  limit?: number;
+  size?: "default" | "sm" | "lg";
+}
+
+export function CollaboratorAvatarsDemo({
+  currentUserId,
+  limit = 3,
+  size = "sm",
+}: CollaboratorAvatarsDemoProps = {}) {
+  return (
+    <div className="flex items-center gap-8 p-4 border rounded-md bg-muted/20">
+      <div className="flex flex-col gap-2">
+        <span className="text-xs text-muted-foreground">Default (3 visible)</span>
+        <CollaboratorAvatars
+          users={sampleUsers}
+          currentUserId={currentUserId}
+          limit={limit}
+          size={size}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs text-muted-foreground">Limit 2</span>
+        <CollaboratorAvatars
+          users={sampleUsers}
+          currentUserId={currentUserId}
+          limit={2}
+          size={size}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs text-muted-foreground">All visible</span>
+        <CollaboratorAvatars
+          users={sampleUsers}
+          currentUserId={currentUserId}
+          limit={10}
+          size={size}
+        />
+      </div>
+    </div>
+  );
+}

--- a/content/docs/cell/collaborator-avatars.mdx
+++ b/content/docs/cell/collaborator-avatars.mdx
@@ -1,0 +1,141 @@
+---
+title: CollaboratorAvatars
+description: Display avatars of users collaborating on a notebook with overflow handling
+icon: Users
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { CollaboratorAvatarsDemo } from '@/app/components/CollaboratorAvatarsDemo';
+
+<div className="my-8">
+  <CollaboratorAvatarsDemo />
+</div>
+
+The CollaboratorAvatars component displays a row of user avatars showing who is currently collaborating on a notebook. It handles overflow gracefully and shows user details on hover.
+
+## Features
+
+- Filters out the current user from display
+- Configurable limit on visible avatars (default 3)
+- Overflow indicator shows "+N" for additional users
+- HoverCard on each avatar shows user info
+- Stacked layout with negative margin overlap
+- Optional color indicator per user
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add https://nteract-elements.vercel.app/r/collaborator-avatars.json
+    ```
+  </Tab>
+  <Tab value="Manual">
+    Copy from [nteract/elements](https://github.com/nteract/elements/tree/main/registry/cell/CollaboratorAvatars.tsx).
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import { CollaboratorAvatars } from "@/registry/cell/CollaboratorAvatars";
+
+const users = [
+  { id: "1", name: "Alice Smith", picture: "https://example.com/alice.jpg", color: "#e91e63" },
+  { id: "2", name: "Bob Johnson", color: "#2196f3" },
+  { id: "3", name: "Carol Williams", picture: "https://example.com/carol.jpg", color: "#4caf50" },
+  { id: "4", name: "David Brown", color: "#ff9800" },
+];
+
+function NotebookHeader() {
+  return (
+    <CollaboratorAvatars
+      users={users}
+      currentUserId="1"
+      limit={3}
+    />
+  );
+}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `users` | `CollaboratorUser[]` | — | Array of user objects to display |
+| `currentUserId` | `string` | — | ID of current user (excluded from display) |
+| `limit` | `number` | `3` | Maximum avatars to show before overflow |
+| `size` | `"default" \| "sm" \| "lg"` | `"sm"` | Avatar size |
+| `className` | `string` | — | Additional classes for the container |
+
+### CollaboratorUser Interface
+
+```tsx
+interface CollaboratorUser {
+  id: string;
+  name: string;
+  picture?: string;
+  color?: string;
+}
+```
+
+## Examples
+
+### Basic Usage
+
+```tsx
+<CollaboratorAvatars
+  users={[
+    { id: "1", name: "Alice" },
+    { id: "2", name: "Bob" },
+  ]}
+/>
+```
+
+### With Current User Filtered
+
+```tsx
+<CollaboratorAvatars
+  users={users}
+  currentUserId="current-user-id"
+/>
+```
+
+### Custom Limit
+
+```tsx
+<CollaboratorAvatars
+  users={users}
+  limit={5}
+/>
+```
+
+### With Colors
+
+Colors can be used to indicate cursor positions or user-specific highlighting in collaborative editing:
+
+```tsx
+<CollaboratorAvatars
+  users={[
+    { id: "1", name: "Alice", color: "#e91e63" },
+    { id: "2", name: "Bob", color: "#2196f3" },
+  ]}
+/>
+```
+
+### In a Cell Header
+
+```tsx
+import { CellHeader } from "@/registry/cell/CellHeader";
+import { CollaboratorAvatars } from "@/registry/cell/CollaboratorAvatars";
+
+<CellHeader
+  leftContent={<PlayButton />}
+  rightContent={
+    <div className="flex items-center gap-2">
+      <CollaboratorAvatars users={collaborators} currentUserId={userId} />
+      <CellControls />
+    </div>
+  }
+/>
+```

--- a/content/docs/cell/meta.json
+++ b/content/docs/cell/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Cell",
-  "pages": ["cell-container", "cell-controls", "cell-header", "output-area", "cell-type-button", "cell-type-selector", "execution-count", "execution-status", "play-button", "runtime-health-indicator"]
+  "pages": ["cell-container", "cell-controls", "cell-header", "collaborator-avatars", "output-area", "cell-type-button", "cell-type-selector", "execution-count", "execution-status", "play-button", "runtime-health-indicator"]
 }

--- a/registry.json
+++ b/registry.json
@@ -496,6 +496,19 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "collaborator-avatars",
+      "type": "registry:component",
+      "title": "CollaboratorAvatars",
+      "description": "Display avatars of users collaborating on a notebook with overflow handling.",
+      "registryDependencies": ["avatar", "hover-card"],
+      "files": [
+        {
+          "path": "registry/cell/CollaboratorAvatars.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/registry/cell/CollaboratorAvatars.tsx
+++ b/registry/cell/CollaboratorAvatars.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+} from "@/registry/primitives/avatar";
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from "@/registry/primitives/hover-card";
+
+export interface CollaboratorUser {
+  id: string;
+  name: string;
+  picture?: string;
+  color?: string;
+}
+
+export interface CollaboratorAvatarsProps {
+  users: CollaboratorUser[];
+  currentUserId?: string;
+  limit?: number;
+  className?: string;
+  size?: "default" | "sm" | "lg";
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export function CollaboratorAvatars({
+  users,
+  currentUserId,
+  limit = 3,
+  className,
+  size = "sm",
+}: CollaboratorAvatarsProps) {
+  // Filter out current user from display
+  const displayUsers = React.useMemo(() => {
+    return currentUserId
+      ? users.filter((user) => user.id !== currentUserId)
+      : users;
+  }, [users, currentUserId]);
+
+  if (displayUsers.length === 0) {
+    return null;
+  }
+
+  const visibleUsers = displayUsers.slice(0, limit);
+  const overflowCount = displayUsers.length - limit;
+  const overflowUsers = displayUsers.slice(limit);
+
+  return (
+    <AvatarGroup className={className}>
+      {visibleUsers.map((user) => (
+        <HoverCard key={user.id} openDelay={200} closeDelay={100}>
+          <HoverCardTrigger asChild>
+            <Avatar
+              size={size}
+              className="cursor-pointer transition-transform hover:scale-110 hover:z-10"
+              style={
+                user.color
+                  ? { boxShadow: `0 0 0 2px ${user.color}` }
+                  : undefined
+              }
+            >
+              {user.picture ? (
+                <AvatarImage src={user.picture} alt={user.name} />
+              ) : null}
+              <AvatarFallback
+                style={
+                  user.color
+                    ? { backgroundColor: user.color, color: "white" }
+                    : undefined
+                }
+              >
+                {getInitials(user.name)}
+              </AvatarFallback>
+            </Avatar>
+          </HoverCardTrigger>
+          <HoverCardContent className="w-auto min-w-[120px] p-3">
+            <div className="flex items-center gap-2">
+              <Avatar size="default">
+                {user.picture ? (
+                  <AvatarImage src={user.picture} alt={user.name} />
+                ) : null}
+                <AvatarFallback
+                  style={
+                    user.color
+                      ? { backgroundColor: user.color, color: "white" }
+                      : undefined
+                  }
+                >
+                  {getInitials(user.name)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="text-sm font-medium">{user.name}</span>
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      ))}
+      {overflowCount > 0 && (
+        <HoverCard openDelay={200} closeDelay={100}>
+          <HoverCardTrigger asChild>
+            <AvatarGroupCount className="cursor-pointer transition-transform hover:scale-110 hover:z-10">
+              +{overflowCount}
+            </AvatarGroupCount>
+          </HoverCardTrigger>
+          <HoverCardContent className="w-auto min-w-[150px] p-3">
+            <div className="space-y-2">
+              {overflowUsers.map((user) => (
+                <div key={user.id} className="flex items-center gap-2">
+                  <Avatar size="sm">
+                    {user.picture ? (
+                      <AvatarImage src={user.picture} alt={user.name} />
+                    ) : null}
+                    <AvatarFallback
+                      style={
+                        user.color
+                          ? { backgroundColor: user.color, color: "white" }
+                          : undefined
+                      }
+                    >
+                      {getInitials(user.name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm">{user.name}</span>
+                </div>
+              ))}
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      )}
+    </AvatarGroup>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `CollaboratorAvatars` component to display user avatars in notebook collaboration
- Filter current user from display, configurable limit, overflow "+N" indicator
- HoverCard on hover shows user details with optional color indicators

Closes #46

## Test plan
- [ ] Run `pnpm run types:check` - passes
- [ ] Import and render component in docs page
- [ ] Verify avatar hover cards work
- [ ] Test overflow with different limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)