### PR TITLE
Standardize component composition patterns and reorder docs

### DIFF
--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -3,11 +3,11 @@
   "pages": [
     "---Getting Started---",
     "index",
-    "---UI---",
-    "...ui",
     "---Cell---",
     "...cell",
     "---Outputs---",
-    "...outputs"
+    "...outputs",
+    "---UI---",
+    "...ui"
   ]
 }

--- a/registry/cell/CellContainer.tsx
+++ b/registry/cell/CellContainer.tsx
@@ -33,6 +33,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
     return (
       <div
         ref={ref}
+        data-slot="cell-container"
         data-cell-id={id}
         className={cn(
           "cell-container group relative border-2 transition-all duration-200",

--- a/registry/cell/CellControls.tsx
+++ b/registry/cell/CellControls.tsx
@@ -71,6 +71,7 @@ export const CellControls: React.FC<CellControlsProps> = ({
 }) => {
   return (
     <div
+      data-slot="cell-controls"
       className={cn(
         "cell-controls flex items-center gap-0.5 transition-opacity",
         forceVisible

--- a/registry/cell/CellHeader.tsx
+++ b/registry/cell/CellHeader.tsx
@@ -20,6 +20,7 @@ export const CellHeader: React.FC<CellHeaderProps> = ({
 }) => {
   return (
     <div
+      data-slot="cell-header"
       className={cn(
         "cell-header flex items-center justify-between px-1 py-2 sm:pr-4",
         className

--- a/registry/cell/CellTypeButton.tsx
+++ b/registry/cell/CellTypeButton.tsx
@@ -51,6 +51,7 @@ export function CellTypeButton({
 
   return (
     <Button
+      data-slot="cell-type-button"
       variant="outline"
       className={cn(
         cellTypeStyles[cellType],

--- a/registry/cell/CellTypeSelector.tsx
+++ b/registry/cell/CellTypeSelector.tsx
@@ -55,6 +55,7 @@ export function CellTypeSelector({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
+          data-slot="cell-type-selector"
           variant="outline"
           size="sm"
           className={cn(

--- a/registry/cell/CollaboratorAvatars.tsx
+++ b/registry/cell/CollaboratorAvatars.tsx
@@ -62,7 +62,7 @@ export function CollaboratorAvatars({
   const overflowUsers = displayUsers.slice(limit);
 
   return (
-    <AvatarGroup className={className}>
+    <AvatarGroup data-slot="collaborator-avatars" className={className}>
       {visibleUsers.map((user) => (
         <HoverCard key={user.id} openDelay={200} closeDelay={100}>
           <HoverCardTrigger asChild>

--- a/registry/cell/ExecutionCount.tsx
+++ b/registry/cell/ExecutionCount.tsx
@@ -13,7 +13,10 @@ export function ExecutionCount({
 }: ExecutionCountProps) {
   const display = isExecuting ? "*" : count ?? " ";
   return (
-    <span className={cn("font-mono text-sm text-muted-foreground", className)}>
+    <span
+      data-slot="execution-count"
+      className={cn("font-mono text-sm text-muted-foreground", className)}
+    >
       [{display}]:
     </span>
   );

--- a/registry/cell/ExecutionStatus.tsx
+++ b/registry/cell/ExecutionStatus.tsx
@@ -13,13 +13,14 @@ export const ExecutionStatus: React.FC<ExecutionStatusProps> = ({
       return null;
     case "queued":
       return (
-        <Badge variant="secondary" className="h-5 text-xs">
+        <Badge data-slot="execution-status" variant="secondary" className="h-5 text-xs">
           Queued
         </Badge>
       );
     case "running":
       return (
         <Badge
+          data-slot="execution-status"
           variant="outline"
           className="h-5 border-blue-200 bg-blue-50 text-xs text-blue-700"
         >
@@ -30,6 +31,7 @@ export const ExecutionStatus: React.FC<ExecutionStatusProps> = ({
     case "error":
       return (
         <Badge
+          data-slot="execution-status"
           variant="outline"
           className="h-5 border-red-200 bg-red-50 text-xs text-red-700"
         >

--- a/registry/cell/OutputArea.tsx
+++ b/registry/cell/OutputArea.tsx
@@ -157,7 +157,7 @@ export function OutputArea({
   const outputCount = outputs.length;
 
   return (
-    <div className={cn("output-area", className)}>
+    <div data-slot="output-area" className={cn("output-area", className)}>
       {/* Collapse toggle */}
       {hasCollapseControl && (
         <button
@@ -198,5 +198,3 @@ export function OutputArea({
     </div>
   );
 }
-
-export default OutputArea;

--- a/registry/cell/PlayButton.tsx
+++ b/registry/cell/PlayButton.tsx
@@ -32,6 +32,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
 
   return (
     <button
+      data-slot="play-button"
       onClick={isRunning ? onInterrupt : onExecute}
       disabled={isAutoLaunching}
       className={cn(

--- a/registry/cell/RuntimeHealthIndicator.tsx
+++ b/registry/cell/RuntimeHealthIndicator.tsx
@@ -86,6 +86,7 @@ export const RuntimeHealthIndicator: React.FC<RuntimeHealthIndicatorProps> = ({
     return (
       <button
         type="button"
+        data-slot="runtime-health-indicator"
         onClick={onClick}
         className={cn(
           "flex items-center gap-1 rounded-md border border-input bg-background px-2 py-1 text-sm transition-colors hover:bg-accent hover:text-accent-foreground sm:gap-2",
@@ -98,7 +99,10 @@ export const RuntimeHealthIndicator: React.FC<RuntimeHealthIndicatorProps> = ({
   }
 
   return (
-    <div className={cn("flex items-center gap-1 sm:gap-2", className)}>
+    <div
+      data-slot="runtime-health-indicator"
+      className={cn("flex items-center gap-1 sm:gap-2", className)}
+    >
       {content}
     </div>
   );

--- a/registry/outputs/ansi-output.tsx
+++ b/registry/outputs/ansi-output.tsx
@@ -1,4 +1,5 @@
 import Ansi from "ansi-to-react";
+import { cn } from "@/lib/utils";
 
 interface AnsiOutputProps {
   children: string;
@@ -20,12 +21,15 @@ export function AnsiOutput({
     return null;
   }
 
-  const baseClasses = `not-prose font-mono text-sm whitespace-pre-wrap leading-relaxed ${className}`;
-  const errorClasses = isError ? "text-red-600" : "";
-  const finalClasses = `${baseClasses} ${errorClasses}`.trim();
-
   return (
-    <div className={finalClasses}>
+    <div
+      data-slot="ansi-output"
+      className={cn(
+        "not-prose font-mono text-sm whitespace-pre-wrap leading-relaxed",
+        isError && "text-red-600",
+        className
+      )}
+    >
       <Ansi useClasses={false}>{children}</Ansi>
     </div>
   );
@@ -49,7 +53,10 @@ export function AnsiStreamOutput({
   const streamClasses = isStderr ? "text-red-600" : "text-gray-700";
 
   return (
-    <div className={`not-prose py-2 ${streamClasses} ${className}`}>
+    <div
+      data-slot="ansi-stream-output"
+      className={cn("not-prose py-2", streamClasses, className)}
+    >
       <AnsiOutput isError={isStderr}>{text}</AnsiOutput>
     </div>
   );
@@ -73,7 +80,8 @@ export function AnsiErrorOutput({
 }: AnsiErrorOutputProps) {
   return (
     <div
-      className={`not-prose border-l-2 border-red-200 py-3 pl-1 ${className}`}
+      data-slot="ansi-error-output"
+      className={cn("not-prose border-l-2 border-red-200 py-3 pl-1", className)}
     >
       {ename && evalue && (
         <div className="mb-1 font-semibold text-red-700">

--- a/registry/outputs/html-output.tsx
+++ b/registry/outputs/html-output.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
 
 interface HtmlOutputProps {
   /**
@@ -82,12 +83,11 @@ export function HtmlOutput({
   return (
     <div
       ref={ref}
-      className={`not-prose py-2 max-w-none overflow-auto ${className}`.trim()}
+      data-slot="html-output"
+      className={cn("not-prose py-2 max-w-none overflow-auto", className)}
       // For SSR/initial render, use dangerouslySetInnerHTML
       // The useEffect will take over on the client
       dangerouslySetInnerHTML={unsafe ? undefined : { __html: content }}
     />
   );
 }
-
-export default HtmlOutput;

--- a/registry/outputs/image-output.tsx
+++ b/registry/outputs/image-output.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 interface ImageOutputProps {
   /**
    * Image data - can be base64 encoded string, data URL, or regular URL
@@ -59,7 +61,7 @@ export function ImageOutput({
   if (height) sizeProps.height = height;
 
   return (
-    <div className={`not-prose py-2 ${className}`.trim()}>
+    <div data-slot="image-output" className={cn("not-prose py-2", className)}>
       <img
         src={src}
         alt={alt}
@@ -70,5 +72,3 @@ export function ImageOutput({
     </div>
   );
 }
-
-export default ImageOutput;

--- a/registry/outputs/json-output.tsx
+++ b/registry/outputs/json-output.tsx
@@ -92,6 +92,7 @@ export function JsonOutput({
   if (data === undefined || data === null) {
     return (
       <div
+        data-slot="json-output"
         className={cn(
           "not-prose py-2 font-mono text-sm text-muted-foreground",
           className
@@ -106,7 +107,7 @@ export function JsonOutput({
     <JsonViewerContext.Provider
       value={{ expandedPaths, togglePath, displayDataTypes }}
     >
-      <div className={cn("not-prose py-2", className)}>
+      <div data-slot="json-output" className={cn("not-prose py-2", className)}>
         <div className="rounded-lg border bg-background p-3 font-mono text-sm">
           <JsonValue value={data} path="$" keyName={null} isLast />
         </div>
@@ -468,5 +469,3 @@ function JsonTypeLabel({ type }: { type: string }) {
     </span>
   );
 }
-
-export default JsonOutput;

--- a/registry/outputs/markdown-output.tsx
+++ b/registry/outputs/markdown-output.tsx
@@ -9,6 +9,7 @@ import rehypeRaw from "rehype-raw";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
 
@@ -132,7 +133,7 @@ export function MarkdownOutput({
   const rehypePlugins = unsafe ? [rehypeKatex, rehypeRaw] : [rehypeKatex];
 
   return (
-    <div className={`not-prose py-2 ${className}`.trim()}>
+    <div data-slot="markdown-output" className={cn("not-prose py-2", className)}>
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
         rehypePlugins={rehypePlugins}
@@ -347,5 +348,3 @@ export function MarkdownOutput({
     </div>
   );
 }
-
-export default MarkdownOutput;

--- a/registry/outputs/media-router.tsx
+++ b/registry/outputs/media-router.tsx
@@ -344,5 +344,3 @@ export function getSelectedMimeType(
 ): string | null {
   return selectMimeType(data, priority);
 }
-
-export default MediaRouter;

--- a/registry/outputs/svg-output.tsx
+++ b/registry/outputs/svg-output.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
 
 interface SvgOutputProps {
   /**
@@ -50,9 +51,8 @@ export function SvgOutput({ data, className = "" }: SvgOutputProps) {
   return (
     <div
       ref={ref}
-      className={`not-prose py-2 max-w-full overflow-auto ${className}`.trim()}
+      data-slot="svg-output"
+      className={cn("not-prose py-2 max-w-full overflow-auto", className)}
     />
   );
 }
-
-export default SvgOutput;


### PR DESCRIPTION
## Summary
- Reorder documentation: Cell and Outputs sections now appear before UI primitives, establishing the correct narrative hierarchy
- Standardize `cn()` usage across output components (replacing template literals with proper class merging)
- Remove default exports from output components for consistency with naming patterns
- Add `data-slot` attributes to all cell and output components for unified styling and testing capabilities

## Test plan
- Type checking passes: `pnpm run types:check`
- All components compile without errors
- Documentation navigation reflects the new hierarchy
- Component composition patterns are now consistent across the registry

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>