### PR TITLE
Use @nteract namespace for registry dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -92,12 +92,12 @@
       "title": "Media Router",
       "description": "MIME type-based output dispatcher that automatically selects the best renderer for Jupyter outputs. Supports custom renderers and priority ordering for platform-specific MIME types.",
       "registryDependencies": [
-        "ansi-output",
-        "markdown-output",
-        "html-output",
-        "image-output",
-        "svg-output",
-        "json-output"
+        "@nteract/ansi-output",
+        "@nteract/markdown-output",
+        "@nteract/html-output",
+        "@nteract/image-output",
+        "@nteract/svg-output",
+        "@nteract/json-output"
       ],
       "files": [
         {
@@ -138,7 +138,7 @@
       "title": "ButtonGroup",
       "description": "Group buttons together with merged borders. Includes ButtonGroupSeparator and ButtonGroupText.",
       "dependencies": ["@radix-ui/react-slot", "class-variance-authority"],
-      "registryDependencies": ["separator"],
+      "registryDependencies": ["@nteract/separator"],
       "files": [
         {
           "path": "registry/primitives/button-group.tsx",
@@ -254,7 +254,7 @@
       "title": "Dialog",
       "description": "A modal dialog component for confirmations, forms, and focused interactions. Includes overlay, header, footer, and close button.",
       "dependencies": ["radix-ui", "lucide-react"],
-      "registryDependencies": ["button"],
+      "registryDependencies": ["@nteract/button"],
       "files": [
         {
           "path": "registry/primitives/dialog.tsx",
@@ -293,7 +293,7 @@
       "title": "CellTypeButton",
       "description": "Styled buttons for different notebook cell types with color coding. Includes CodeCellButton, MarkdownCellButton, SqlCellButton, and AiCellButton convenience components.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["button"],
+      "registryDependencies": ["@nteract/button"],
       "files": [
         {
           "path": "registry/cell/CellTypeButton.tsx",
@@ -306,7 +306,7 @@
       "type": "registry:component",
       "title": "ExecutionStatus",
       "description": "A badge component that displays the execution state of a notebook cell. Shows queued, running, or error states.",
-      "registryDependencies": ["badge"],
+      "registryDependencies": ["@nteract/badge"],
       "files": [
         {
           "path": "registry/cell/ExecutionStatus.tsx",
@@ -346,7 +346,7 @@
       "title": "CellControls",
       "description": "Cell action menu with source visibility toggle, move controls, and dropdown menu for delete and clear operations.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["button", "dropdown-menu"],
+      "registryDependencies": ["@nteract/button", "@nteract/dropdown-menu"],
       "files": [
         {
           "path": "registry/cell/CellControls.tsx",
@@ -410,7 +410,7 @@
       "title": "OutputArea",
       "description": "Wrapper component for rendering multiple Jupyter outputs with collapsible state and scroll behavior.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["media-router", "ansi-output"],
+      "registryDependencies": ["@nteract/media-router", "@nteract/ansi-output"],
       "files": [
         {
           "path": "registry/cell/OutputArea.tsx",
@@ -462,7 +462,7 @@
       "title": "Command",
       "description": "A command palette component for keyboard-driven navigation and actions. Built on cmdk with dialog support.",
       "dependencies": ["cmdk", "lucide-react"],
-      "registryDependencies": ["dialog"],
+      "registryDependencies": ["@nteract/dialog"],
       "files": [
         {
           "path": "registry/primitives/command.tsx",
@@ -489,7 +489,7 @@
       "title": "CellTypeSelector",
       "description": "A dropdown selector for changing cell types in notebook interfaces. Supports filtering available types and displays the current type with color-coded styling.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["button", "dropdown-menu", "cell-type-button"],
+      "registryDependencies": ["@nteract/button", "@nteract/dropdown-menu", "@nteract/cell-type-button"],
       "files": [
         {
           "path": "registry/cell/CellTypeSelector.tsx",
@@ -502,7 +502,7 @@
       "type": "registry:component",
       "title": "CollaboratorAvatars",
       "description": "Display avatars of users collaborating on a notebook with overflow handling.",
-      "registryDependencies": ["avatar", "hover-card"],
+      "registryDependencies": ["@nteract/avatar", "@nteract/hover-card"],
       "files": [
         {
           "path": "registry/cell/CollaboratorAvatars.tsx",
@@ -515,7 +515,7 @@
       "type": "registry:component",
       "title": "PresenceBookmarks",
       "description": "Shows stacked user avatars indicating who is present on a cell. Displays a HoverCard with user details and a +N overflow indicator when users exceed the limit.",
-      "registryDependencies": ["avatar", "hover-card"],
+      "registryDependencies": ["@nteract/avatar", "@nteract/hover-card"],
       "files": [
         {
           "path": "registry/cell/PresenceBookmarks.tsx",
@@ -580,7 +580,7 @@
       "title": "Alert Dialog",
       "description": "A modal dialog for critical confirmations that require user acknowledgment. Built on Radix UI with accessible focus management.",
       "dependencies": ["radix-ui"],
-      "registryDependencies": ["button"],
+      "registryDependencies": ["@nteract/button"],
       "files": [
         {
           "path": "registry/primitives/alert-dialog.tsx",


### PR DESCRIPTION
## Summary
Convert all `registryDependencies` in `registry.json` to use the `@nteract/` namespace prefix. This ensures external users can properly resolve component dependencies when installing from the nteract registry.

This change works in conjunction with the namespace registration submitted to shadcn-ui/ui (#9550), allowing users to install components with commands like `npx shadcn@latest add @nteract/media-router`.

## Changes
- Updated 12 components with `registryDependencies` to use namespaced references
- All internal component references now prefixed with `@nteract/`
- Registry builds successfully with validated dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)