### PR TITLE
Add layout container widgets (VBox, HBox, GridBox, Accordion, Tab)

### DIFF
--- a/app/components/BuiltinWidgetsDemo.tsx
+++ b/app/components/BuiltinWidgetsDemo.tsx
@@ -127,6 +127,136 @@ const DEMO_WIDGETS = [
   },
 ];
 
+// Layout widget configurations (separate for clearer demo)
+const LAYOUT_WIDGETS = [
+  // Extra buttons for layout demos
+  {
+    id: "layout-btn-1",
+    name: "ButtonModel",
+    state: { description: "Button 1", button_style: "info" },
+  },
+  {
+    id: "layout-btn-2",
+    name: "ButtonModel",
+    state: { description: "Button 2", button_style: "success" },
+  },
+  {
+    id: "layout-btn-3",
+    name: "ButtonModel",
+    state: { description: "Button 3", button_style: "warning" },
+  },
+  // VBox with buttons
+  {
+    id: "demo-vbox",
+    name: "VBoxModel",
+    state: {
+      children: [
+        "IPY_MODEL_layout-btn-1",
+        "IPY_MODEL_layout-btn-2",
+        "IPY_MODEL_layout-btn-3",
+      ],
+      box_style: "info",
+    },
+  },
+  // Extra sliders for HBox
+  {
+    id: "layout-slider-1",
+    name: "IntSliderModel",
+    state: { value: 25, min: 0, max: 100, description: "A:" },
+  },
+  {
+    id: "layout-slider-2",
+    name: "IntSliderModel",
+    state: { value: 75, min: 0, max: 100, description: "B:" },
+  },
+  // HBox with sliders
+  {
+    id: "demo-hbox",
+    name: "HBoxModel",
+    state: {
+      children: ["IPY_MODEL_layout-slider-1", "IPY_MODEL_layout-slider-2"],
+      box_style: "",
+    },
+  },
+  // GridBox with mixed widgets
+  {
+    id: "layout-check-1",
+    name: "CheckboxModel",
+    state: { value: true, description: "Option A" },
+  },
+  {
+    id: "layout-check-2",
+    name: "CheckboxModel",
+    state: { value: false, description: "Option B" },
+  },
+  {
+    id: "layout-check-3",
+    name: "CheckboxModel",
+    state: { value: true, description: "Option C" },
+  },
+  {
+    id: "layout-check-4",
+    name: "CheckboxModel",
+    state: { value: false, description: "Option D" },
+  },
+  {
+    id: "demo-gridbox",
+    name: "GridBoxModel",
+    state: {
+      children: [
+        "IPY_MODEL_layout-check-1",
+        "IPY_MODEL_layout-check-2",
+        "IPY_MODEL_layout-check-3",
+        "IPY_MODEL_layout-check-4",
+      ],
+      box_style: "success",
+    },
+  },
+  // Tab widget
+  {
+    id: "tab-content-1",
+    name: "TextModel",
+    state: { value: "", description: "Tab 1 input:", placeholder: "Type here..." },
+  },
+  {
+    id: "tab-content-2",
+    name: "IntSliderModel",
+    state: { value: 50, min: 0, max: 100, description: "Tab 2 slider:" },
+  },
+  {
+    id: "demo-tab",
+    name: "TabModel",
+    state: {
+      children: ["IPY_MODEL_tab-content-1", "IPY_MODEL_tab-content-2"],
+      _titles: ["Text Input", "Slider Control"],
+      selected_index: 0,
+    },
+  },
+  // Accordion widget
+  {
+    id: "accordion-content-1",
+    name: "TextareaModel",
+    state: { value: "", description: "", placeholder: "Panel 1 content...", rows: 2 },
+  },
+  {
+    id: "accordion-content-2",
+    name: "CheckboxModel",
+    state: { value: false, description: "Enable in panel 2" },
+  },
+  {
+    id: "demo-accordion",
+    name: "AccordionModel",
+    state: {
+      children: ["IPY_MODEL_accordion-content-1", "IPY_MODEL_accordion-content-2"],
+      _titles: ["Panel One", "Panel Two"],
+      selected_index: 0,
+    },
+  },
+];
+
+// Combined list for widget creation
+const ALL_WIDGETS = [...DEMO_WIDGETS, ...LAYOUT_WIDGETS];
+
 // === Demo Components ===
 
 function DemoControls() {
@@ -141,7 +271,7 @@ function DemoControls() {
   };
 
   const createAllWidgets = () => {
-    for (const widget of DEMO_WIDGETS) {
+    for (const widget of ALL_WIDGETS) {
       if (!models.has(widget.id)) {
         handleMessage(createWidgetMessage(widget.id, widget.name, widget.state));
         addLog(`Created ${widget.name}`);
@@ -196,6 +326,15 @@ function DemoControls() {
   );
 }
 
+// Layout widget IDs to show (not the child widgets)
+const LAYOUT_DISPLAY_WIDGETS = [
+  "demo-vbox",
+  "demo-hbox",
+  "demo-gridbox",
+  "demo-tab",
+  "demo-accordion",
+];
+
 function WidgetDisplay() {
   const models = useWidgetModels();
 
@@ -208,17 +347,48 @@ function WidgetDisplay() {
   }
 
   return (
-    <div className="space-y-4">
-      {DEMO_WIDGETS.map(
-        (widget) =>
-          models.has(widget.id) && (
-            <div key={widget.id} className="border rounded-lg p-4">
-              <div className="text-xs text-muted-foreground mb-2">
-                {widget.name}
-              </div>
-              <WidgetView modelId={widget.id} />
-            </div>
-          )
+    <div className="space-y-6">
+      {/* Control widgets */}
+      <div>
+        <h4 className="text-sm font-medium text-muted-foreground mb-3">
+          Control Widgets
+        </h4>
+        <div className="space-y-4">
+          {DEMO_WIDGETS.map(
+            (widget) =>
+              models.has(widget.id) && (
+                <div key={widget.id} className="border rounded-lg p-4">
+                  <div className="text-xs text-muted-foreground mb-2">
+                    {widget.name}
+                  </div>
+                  <WidgetView modelId={widget.id} />
+                </div>
+              )
+          )}
+        </div>
+      </div>
+
+      {/* Layout widgets */}
+      {LAYOUT_DISPLAY_WIDGETS.some((id) => models.has(id)) && (
+        <div>
+          <h4 className="text-sm font-medium text-muted-foreground mb-3">
+            Layout Widgets
+          </h4>
+          <div className="space-y-4">
+            {LAYOUT_DISPLAY_WIDGETS.map((widgetId) => {
+              const model = models.get(widgetId);
+              if (!model) return null;
+              return (
+                <div key={widgetId} className="border rounded-lg p-4">
+                  <div className="text-xs text-muted-foreground mb-2">
+                    {model.modelName}
+                  </div>
+                  <WidgetView modelId={widgetId} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/registry/primitives/accordion.tsx
+++ b/registry/primitives/accordion.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+import { Accordion as AccordionPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/registry/widgets/controls/accordion-widget.tsx
+++ b/registry/widgets/controls/accordion-widget.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Accordion widget - collapsible panel container.
+ *
+ * Maps to ipywidgets AccordionModel. Displays children as collapsible panels.
+ */
+
+import { cn } from "@/lib/utils";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+  parseModelRef,
+} from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/registry/primitives/accordion";
+
+export function AccordionWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const children = useWidgetModelValue<string[]>(modelId, "children");
+  const titles = useWidgetModelValue<string[]>(modelId, "_titles") ?? [];
+  const selectedIndex = useWidgetModelValue<number | null>(
+    modelId,
+    "selected_index"
+  );
+
+  const handleValueChange = (value: string) => {
+    // Convert string value back to index (or null if collapsed)
+    const index = value !== "" ? parseInt(value, 10) : null;
+    sendUpdate(modelId, { selected_index: index });
+  };
+
+  return (
+    <Accordion
+      type="single"
+      collapsible
+      value={selectedIndex !== null ? String(selectedIndex) : ""}
+      onValueChange={handleValueChange}
+      className={cn("w-full", className)}
+      data-widget-id={modelId}
+      data-widget-type="Accordion"
+    >
+      {children?.map((childRef, index) => {
+        const childId = parseModelRef(childRef);
+        if (!childId) return null;
+
+        return (
+          <AccordionItem key={childId} value={String(index)}>
+            <AccordionTrigger>
+              {titles[index] ?? `Panel ${index + 1}`}
+            </AccordionTrigger>
+            <AccordionContent>
+              <WidgetView modelId={childId} />
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
+    </Accordion>
+  );
+}
+
+export default AccordionWidget;

--- a/registry/widgets/controls/box-widget.tsx
+++ b/registry/widgets/controls/box-widget.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Box widget - generic flex container.
+ *
+ * Maps to ipywidgets BoxModel. Base container for layout widgets.
+ * Defaults to vertical stacking (like VBox).
+ */
+
+import { cn } from "@/lib/utils";
+import { useWidgetModelValue, parseModelRef } from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import type { WidgetComponentProps } from "../widget-registry";
+
+// Map ipywidgets box_style to Tailwind classes
+const BOX_STYLE_MAP: Record<string, string> = {
+  "": "",
+  primary: "border border-blue-500 bg-blue-50/50 dark:bg-blue-950/50 rounded-md p-2",
+  success: "border border-green-500 bg-green-50/50 dark:bg-green-950/50 rounded-md p-2",
+  info: "border border-sky-500 bg-sky-50/50 dark:bg-sky-950/50 rounded-md p-2",
+  warning: "border border-yellow-500 bg-yellow-50/50 dark:bg-yellow-950/50 rounded-md p-2",
+  danger: "border border-red-500 bg-red-50/50 dark:bg-red-950/50 rounded-md p-2",
+};
+
+export function BoxWidget({ modelId, className }: WidgetComponentProps) {
+  // Subscribe to individual state keys
+  const children = useWidgetModelValue<string[]>(modelId, "children");
+  const boxStyle = useWidgetModelValue<string>(modelId, "box_style") ?? "";
+
+  const styleClass = BOX_STYLE_MAP[boxStyle] ?? "";
+
+  return (
+    <div
+      className={cn("flex flex-col gap-2", styleClass, className)}
+      data-widget-id={modelId}
+      data-widget-type="Box"
+    >
+      {children?.map((childRef) => {
+        const childId = parseModelRef(childRef);
+        return childId ? <WidgetView key={childId} modelId={childId} /> : null;
+      })}
+    </div>
+  );
+}
+
+export default BoxWidget;

--- a/registry/widgets/controls/gridbox-widget.tsx
+++ b/registry/widgets/controls/gridbox-widget.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * GridBox widget - CSS grid container.
+ *
+ * Maps to ipywidgets GridBoxModel. Arranges children in a CSS grid layout.
+ * Default is a responsive 2-column grid.
+ */
+
+import { cn } from "@/lib/utils";
+import { useWidgetModelValue, parseModelRef } from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import type { WidgetComponentProps } from "../widget-registry";
+
+// Map ipywidgets box_style to Tailwind classes
+const BOX_STYLE_MAP: Record<string, string> = {
+  "": "",
+  primary: "border border-blue-500 bg-blue-50/50 dark:bg-blue-950/50 rounded-md p-2",
+  success: "border border-green-500 bg-green-50/50 dark:bg-green-950/50 rounded-md p-2",
+  info: "border border-sky-500 bg-sky-50/50 dark:bg-sky-950/50 rounded-md p-2",
+  warning: "border border-yellow-500 bg-yellow-50/50 dark:bg-yellow-950/50 rounded-md p-2",
+  danger: "border border-red-500 bg-red-50/50 dark:bg-red-950/50 rounded-md p-2",
+};
+
+export function GridBoxWidget({ modelId, className }: WidgetComponentProps) {
+  // Subscribe to individual state keys
+  const children = useWidgetModelValue<string[]>(modelId, "children");
+  const boxStyle = useWidgetModelValue<string>(modelId, "box_style") ?? "";
+
+  const styleClass = BOX_STYLE_MAP[boxStyle] ?? "";
+
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 sm:grid-cols-2 gap-2",
+        styleClass,
+        className
+      )}
+      data-widget-id={modelId}
+      data-widget-type="GridBox"
+    >
+      {children?.map((childRef) => {
+        const childId = parseModelRef(childRef);
+        return childId ? <WidgetView key={childId} modelId={childId} /> : null;
+      })}
+    </div>
+  );
+}
+
+export default GridBoxWidget;

--- a/registry/widgets/controls/hbox-widget.tsx
+++ b/registry/widgets/controls/hbox-widget.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * HBox widget - horizontal flex container.
+ *
+ * Maps to ipywidgets HBoxModel. Arranges children in a horizontal row.
+ */
+
+import { cn } from "@/lib/utils";
+import { useWidgetModelValue, parseModelRef } from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import type { WidgetComponentProps } from "../widget-registry";
+
+// Map ipywidgets box_style to Tailwind classes
+const BOX_STYLE_MAP: Record<string, string> = {
+  "": "",
+  primary: "border border-blue-500 bg-blue-50/50 dark:bg-blue-950/50 rounded-md p-2",
+  success: "border border-green-500 bg-green-50/50 dark:bg-green-950/50 rounded-md p-2",
+  info: "border border-sky-500 bg-sky-50/50 dark:bg-sky-950/50 rounded-md p-2",
+  warning: "border border-yellow-500 bg-yellow-50/50 dark:bg-yellow-950/50 rounded-md p-2",
+  danger: "border border-red-500 bg-red-50/50 dark:bg-red-950/50 rounded-md p-2",
+};
+
+export function HBoxWidget({ modelId, className }: WidgetComponentProps) {
+  // Subscribe to individual state keys
+  const children = useWidgetModelValue<string[]>(modelId, "children");
+  const boxStyle = useWidgetModelValue<string>(modelId, "box_style") ?? "";
+
+  const styleClass = BOX_STYLE_MAP[boxStyle] ?? "";
+
+  return (
+    <div
+      className={cn("flex flex-row flex-wrap items-start gap-2", styleClass, className)}
+      data-widget-id={modelId}
+      data-widget-type="HBox"
+    >
+      {children?.map((childRef) => {
+        const childId = parseModelRef(childRef);
+        return childId ? <WidgetView key={childId} modelId={childId} /> : null;
+      })}
+    </div>
+  );
+}
+
+export default HBoxWidget;

--- a/registry/widgets/controls/index.ts
+++ b/registry/widgets/controls/index.ts
@@ -17,6 +17,14 @@ import { CheckboxWidget } from "./checkbox-widget";
 import { TextWidget } from "./text-widget";
 import { TextareaWidget } from "./textarea-widget";
 
+// Import layout widget components
+import { VBoxWidget } from "./vbox-widget";
+import { HBoxWidget } from "./hbox-widget";
+import { BoxWidget } from "./box-widget";
+import { GridBoxWidget } from "./gridbox-widget";
+import { AccordionWidget } from "./accordion-widget";
+import { TabWidget } from "./tab-widget";
+
 // Register all widgets with their model names
 registerWidget("IntSliderModel", IntSlider);
 registerWidget("FloatSliderModel", FloatSlider);
@@ -27,6 +35,14 @@ registerWidget("CheckboxModel", CheckboxWidget);
 registerWidget("TextModel", TextWidget);
 registerWidget("TextareaModel", TextareaWidget);
 
+// Register layout widgets
+registerWidget("VBoxModel", VBoxWidget);
+registerWidget("HBoxModel", HBoxWidget);
+registerWidget("BoxModel", BoxWidget);
+registerWidget("GridBoxModel", GridBoxWidget);
+registerWidget("AccordionModel", AccordionWidget);
+registerWidget("TabModel", TabWidget);
+
 // Re-export components for direct use
 export { IntSlider } from "./int-slider";
 export { FloatSlider } from "./float-slider";
@@ -36,3 +52,11 @@ export { ButtonWidget } from "./button-widget";
 export { CheckboxWidget } from "./checkbox-widget";
 export { TextWidget } from "./text-widget";
 export { TextareaWidget } from "./textarea-widget";
+
+// Re-export layout widgets
+export { VBoxWidget } from "./vbox-widget";
+export { HBoxWidget } from "./hbox-widget";
+export { BoxWidget } from "./box-widget";
+export { GridBoxWidget } from "./gridbox-widget";
+export { AccordionWidget } from "./accordion-widget";
+export { TabWidget } from "./tab-widget";

--- a/registry/widgets/controls/tab-widget.tsx
+++ b/registry/widgets/controls/tab-widget.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * Tab widget - tabbed panel container.
+ *
+ * Maps to ipywidgets TabModel. Displays children as tabbed panels.
+ */
+
+import { cn } from "@/lib/utils";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+  parseModelRef,
+} from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/registry/primitives/tabs";
+
+export function TabWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const children = useWidgetModelValue<string[]>(modelId, "children");
+  const titles = useWidgetModelValue<string[]>(modelId, "_titles") ?? [];
+  const selectedIndex =
+    useWidgetModelValue<number>(modelId, "selected_index") ?? 0;
+
+  const handleValueChange = (value: string) => {
+    sendUpdate(modelId, { selected_index: parseInt(value, 10) });
+  };
+
+  return (
+    <Tabs
+      value={String(selectedIndex)}
+      onValueChange={handleValueChange}
+      className={cn("w-full", className)}
+      data-widget-id={modelId}
+      data-widget-type="Tab"
+    >
+      <TabsList>
+        {children?.map((_, index) => (
+          <TabsTrigger key={index} value={String(index)}>
+            {titles[index] ?? `Tab ${index + 1}`}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {children?.map((childRef, index) => {
+        const childId = parseModelRef(childRef);
+        if (!childId) return null;
+
+        return (
+          <TabsContent key={childId} value={String(index)}>
+            <WidgetView modelId={childId} />
+          </TabsContent>
+        );
+      })}
+    </Tabs>
+  );
+}
+
+export default TabWidget;

--- a/registry/widgets/controls/vbox-widget.tsx
+++ b/registry/widgets/controls/vbox-widget.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * VBox widget - vertical flex container.
+ *
+ * Maps to ipywidgets VBoxModel. Arranges children in a vertical column.
+ */
+
+import { cn } from "@/lib/utils";
+import { useWidgetModelValue, parseModelRef } from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import type { WidgetComponentProps } from "../widget-registry";
+
+// Map ipywidgets box_style to Tailwind classes
+const BOX_STYLE_MAP: Record<string, string> = {
+  "": "",
+  primary: "border border-blue-500 bg-blue-50/50 dark:bg-blue-950/50 rounded-md p-2",
+  success: "border border-green-500 bg-green-50/50 dark:bg-green-950/50 rounded-md p-2",
+  info: "border border-sky-500 bg-sky-50/50 dark:bg-sky-950/50 rounded-md p-2",
+  warning: "border border-yellow-500 bg-yellow-50/50 dark:bg-yellow-950/50 rounded-md p-2",
+  danger: "border border-red-500 bg-red-50/50 dark:bg-red-950/50 rounded-md p-2",
+};
+
+export function VBoxWidget({ modelId, className }: WidgetComponentProps) {
+  // Subscribe to individual state keys
+  const children = useWidgetModelValue<string[]>(modelId, "children");
+  const boxStyle = useWidgetModelValue<string>(modelId, "box_style") ?? "";
+
+  const styleClass = BOX_STYLE_MAP[boxStyle] ?? "";
+
+  return (
+    <div
+      className={cn("flex flex-col gap-2", styleClass, className)}
+      data-widget-id={modelId}
+      data-widget-type="VBox"
+    >
+      {children?.map((childRef) => {
+        const childId = parseModelRef(childRef);
+        return childId ? <WidgetView key={childId} modelId={childId} /> : null;
+      })}
+    </div>
+  );
+}
+
+export default VBoxWidget;


### PR DESCRIPTION
## Summary

Implement built-in React components for ipywidgets layout containers, resolving #77. Adds six new widget types that render child widgets arranged via flexbox or CSS grid layouts, with support for box_style variants and state synchronization back to the kernel.

## Implementation

- **VBox/HBox/Box**: Flex-based containers with gap spacing and box_style color variants
- **GridBox**: Responsive CSS grid (1 col mobile, 2 col desktop)
- **Accordion/Tab**: Collapsible/tabbed panels using shadcn primitives with selected_index sync
- All widgets render children via `WidgetView` component using `IPY_MODEL_xxx` references
- Comprehensive demo with examples of nested layouts and state interaction

## Verification

- TypeScript type check passes
- All 9 files compile without errors
- Demo includes interactive examples for all layout widget types