### PR TITLE
Add selection widget components (Dropdown, Radio, Toggle)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -682,8 +682,8 @@
       "name": "widget-controls",
       "type": "registry:component",
       "title": "Widget Controls",
-      "description": "Built-in shadcn-backed widget components for standard ipywidgets (IntSlider, FloatSlider, IntProgress, Button, Checkbox, Text, Textarea).",
-      "registryDependencies": ["@nteract/widget-view", "slider", "progress", "button", "checkbox", "input", "textarea", "label"],
+      "description": "Built-in shadcn-backed widget components for standard ipywidgets (IntSlider, FloatSlider, IntProgress, Button, Checkbox, Text, Textarea, Dropdown, RadioButtons, ToggleButton, ToggleButtons, SelectMultiple).",
+      "registryDependencies": ["@nteract/widget-view", "slider", "progress", "button", "checkbox", "input", "textarea", "label", "select", "radio-group", "toggle", "toggle-group"],
       "files": [
         {
           "path": "registry/widgets/controls/index.ts",
@@ -720,6 +720,26 @@
         {
           "path": "registry/widgets/controls/textarea-widget.tsx",
           "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/dropdown-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/radio-buttons-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/select-multiple-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/toggle-button-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/toggle-buttons-widget.tsx",
+          "type": "registry:component"
         }
       ]
     },
@@ -743,6 +763,59 @@
       "files": [
         {
           "path": "registry/primitives/checkbox.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "select",
+      "type": "registry:ui",
+      "title": "Select",
+      "description": "Select dropdown component built on Radix UI Select primitive.",
+      "dependencies": ["radix-ui", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/primitives/select.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "radio-group",
+      "type": "registry:ui",
+      "title": "Radio Group",
+      "description": "Radio group component built on Radix UI RadioGroup primitive.",
+      "dependencies": ["radix-ui", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/primitives/radio-group.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "toggle",
+      "type": "registry:ui",
+      "title": "Toggle",
+      "description": "Toggle button component built on Radix UI Toggle primitive.",
+      "dependencies": ["radix-ui", "class-variance-authority"],
+      "files": [
+        {
+          "path": "registry/primitives/toggle.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "toggle-group",
+      "type": "registry:ui",
+      "title": "Toggle Group",
+      "description": "Toggle button group component built on Radix UI ToggleGroup primitive.",
+      "dependencies": ["radix-ui", "class-variance-authority"],
+      "registryDependencies": ["@nteract/toggle"],
+      "files": [
+        {
+          "path": "registry/primitives/toggle-group.tsx",
           "type": "registry:ui"
         }
       ]

--- a/registry/primitives/radio-group.tsx
+++ b/registry/primitives/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import { CircleIcon } from "lucide-react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/registry/primitives/select.tsx
+++ b/registry/primitives/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/registry/primitives/toggle-group.tsx
+++ b/registry/primitives/toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/registry/primitives/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/registry/primitives/toggle.tsx
+++ b/registry/primitives/toggle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/registry/widgets/controls/dropdown-widget.tsx
+++ b/registry/widgets/controls/dropdown-widget.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Dropdown widget - renders a select/combobox dropdown.
+ *
+ * Maps to ipywidgets DropdownModel.
+ */
+
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/primitives/select";
+import { Label } from "@/registry/primitives/label";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+import type { WidgetComponentProps } from "../widget-registry";
+
+export function DropdownWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const options =
+    useWidgetModelValue<string[]>(modelId, "_options_labels") ?? [];
+  const index = useWidgetModelValue<number | null>(modelId, "index");
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+
+  // Convert index to string value for Select (Radix Select uses string values)
+  const value =
+    index !== null && index !== undefined && index >= 0
+      ? String(index)
+      : undefined;
+
+  const handleValueChange = (newValue: string) => {
+    const newIndex = parseInt(newValue, 10);
+    if (!isNaN(newIndex)) {
+      sendUpdate(modelId, { index: newIndex });
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="Dropdown"
+    >
+      {description && (
+        <Label className="shrink-0 text-sm">{description}</Label>
+      )}
+      <Select
+        value={value}
+        onValueChange={handleValueChange}
+        disabled={disabled}
+      >
+        <SelectTrigger className="w-48">
+          <SelectValue placeholder="Select..." />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option, idx) => (
+            <SelectItem key={idx} value={String(idx)}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export default DropdownWidget;

--- a/registry/widgets/controls/index.ts
+++ b/registry/widgets/controls/index.ts
@@ -16,6 +16,12 @@ import { ButtonWidget } from "./button-widget";
 import { CheckboxWidget } from "./checkbox-widget";
 import { TextWidget } from "./text-widget";
 import { TextareaWidget } from "./textarea-widget";
+// Selection widgets
+import { DropdownWidget } from "./dropdown-widget";
+import { RadioButtonsWidget } from "./radio-buttons-widget";
+import { SelectMultipleWidget } from "./select-multiple-widget";
+import { ToggleButtonWidget } from "./toggle-button-widget";
+import { ToggleButtonsWidget } from "./toggle-buttons-widget";
 
 // Import layout widget components
 import { VBoxWidget } from "./vbox-widget";
@@ -34,6 +40,12 @@ registerWidget("ButtonModel", ButtonWidget);
 registerWidget("CheckboxModel", CheckboxWidget);
 registerWidget("TextModel", TextWidget);
 registerWidget("TextareaModel", TextareaWidget);
+// Selection widgets
+registerWidget("DropdownModel", DropdownWidget);
+registerWidget("RadioButtonsModel", RadioButtonsWidget);
+registerWidget("SelectMultipleModel", SelectMultipleWidget);
+registerWidget("ToggleButtonModel", ToggleButtonWidget);
+registerWidget("ToggleButtonsModel", ToggleButtonsWidget);
 
 // Register layout widgets
 registerWidget("VBoxModel", VBoxWidget);
@@ -52,6 +64,12 @@ export { ButtonWidget } from "./button-widget";
 export { CheckboxWidget } from "./checkbox-widget";
 export { TextWidget } from "./text-widget";
 export { TextareaWidget } from "./textarea-widget";
+// Selection widgets
+export { DropdownWidget } from "./dropdown-widget";
+export { RadioButtonsWidget } from "./radio-buttons-widget";
+export { SelectMultipleWidget } from "./select-multiple-widget";
+export { ToggleButtonWidget } from "./toggle-button-widget";
+export { ToggleButtonsWidget } from "./toggle-buttons-widget";
 
 // Re-export layout widgets
 export { VBoxWidget } from "./vbox-widget";

--- a/registry/widgets/controls/radio-buttons-widget.tsx
+++ b/registry/widgets/controls/radio-buttons-widget.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * RadioButtons widget - renders a group of radio buttons.
+ *
+ * Maps to ipywidgets RadioButtonsModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { RadioGroup, RadioGroupItem } from "@/registry/primitives/radio-group";
+import { Label } from "@/registry/primitives/label";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+import type { WidgetComponentProps } from "../widget-registry";
+
+export function RadioButtonsWidget({
+  modelId,
+  className,
+}: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const options =
+    useWidgetModelValue<string[]>(modelId, "_options_labels") ?? [];
+  const index = useWidgetModelValue<number | null>(modelId, "index");
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+
+  // Convert index to string value for RadioGroup
+  const value =
+    index !== null && index !== undefined && index >= 0
+      ? String(index)
+      : undefined;
+
+  const handleValueChange = (newValue: string) => {
+    const newIndex = parseInt(newValue, 10);
+    if (!isNaN(newIndex)) {
+      sendUpdate(modelId, { index: newIndex });
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex items-start gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="RadioButtons"
+    >
+      {description && (
+        <Label className="shrink-0 text-sm pt-0.5">{description}</Label>
+      )}
+      <RadioGroup
+        value={value}
+        onValueChange={handleValueChange}
+        disabled={disabled}
+      >
+        {options.map((option, idx) => (
+          <div key={idx} className="flex items-center gap-2">
+            <RadioGroupItem
+              value={String(idx)}
+              id={`${modelId}-radio-${idx}`}
+              disabled={disabled}
+            />
+            <Label
+              htmlFor={`${modelId}-radio-${idx}`}
+              className={cn(
+                "text-sm font-normal cursor-pointer",
+                disabled && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              {option}
+            </Label>
+          </div>
+        ))}
+      </RadioGroup>
+    </div>
+  );
+}
+
+export default RadioButtonsWidget;

--- a/registry/widgets/controls/select-multiple-widget.tsx
+++ b/registry/widgets/controls/select-multiple-widget.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+/**
+ * SelectMultiple widget - renders a multi-select listbox.
+ *
+ * Maps to ipywidgets SelectMultipleModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/registry/primitives/label";
+import { CheckIcon } from "lucide-react";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+import type { WidgetComponentProps } from "../widget-registry";
+
+export function SelectMultipleWidget({
+  modelId,
+  className,
+}: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const options =
+    useWidgetModelValue<string[]>(modelId, "_options_labels") ?? [];
+  const selectedIndices = useWidgetModelValue<number[]>(modelId, "index") ?? [];
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const rows = useWidgetModelValue<number>(modelId, "rows") ?? 5;
+
+  const handleToggle = (idx: number) => {
+    if (disabled) return;
+
+    const newIndices = selectedIndices.includes(idx)
+      ? selectedIndices.filter((i) => i !== idx)
+      : [...selectedIndices, idx].sort((a, b) => a - b);
+
+    sendUpdate(modelId, { index: newIndices });
+  };
+
+  // Calculate height based on rows
+  const itemHeight = 32; // approximate height per item in px
+  const maxHeight = rows * itemHeight;
+
+  return (
+    <div
+      className={cn("flex items-start gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="SelectMultiple"
+    >
+      {description && (
+        <Label className="shrink-0 text-sm pt-1">{description}</Label>
+      )}
+      <div
+        role="listbox"
+        aria-multiselectable="true"
+        aria-disabled={disabled}
+        className={cn(
+          "w-48 overflow-y-auto rounded-md border border-input bg-background shadow-xs",
+          disabled && "opacity-50 cursor-not-allowed"
+        )}
+        style={{ maxHeight }}
+      >
+        {options.map((option, idx) => {
+          const isSelected = selectedIndices.includes(idx);
+          return (
+            <div
+              key={idx}
+              role="option"
+              aria-selected={isSelected}
+              onClick={() => handleToggle(idx)}
+              className={cn(
+                "flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer select-none",
+                "hover:bg-accent hover:text-accent-foreground",
+                isSelected && "bg-accent/50",
+                disabled && "pointer-events-none"
+              )}
+            >
+              <span className="flex size-4 items-center justify-center">
+                {isSelected && <CheckIcon className="size-3" />}
+              </span>
+              <span>{option}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default SelectMultipleWidget;

--- a/registry/widgets/controls/toggle-button-widget.tsx
+++ b/registry/widgets/controls/toggle-button-widget.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * ToggleButton widget - renders a single toggle button.
+ *
+ * Maps to ipywidgets ToggleButtonModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { Toggle } from "@/registry/primitives/toggle";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+import type { WidgetComponentProps } from "../widget-registry";
+
+export function ToggleButtonWidget({
+  modelId,
+  className,
+}: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const value = useWidgetModelValue<boolean>(modelId, "value") ?? false;
+  const description =
+    useWidgetModelValue<string>(modelId, "description") ?? "";
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const icon = useWidgetModelValue<string>(modelId, "icon");
+  const buttonStyle =
+    useWidgetModelValue<string>(modelId, "button_style") ?? "";
+
+  const handlePressedChange = (pressed: boolean) => {
+    sendUpdate(modelId, { value: pressed });
+  };
+
+  // Map button_style to variant - outline for styled buttons
+  const variant = buttonStyle ? "outline" : "default";
+
+  return (
+    <Toggle
+      pressed={value}
+      onPressedChange={handlePressedChange}
+      disabled={disabled}
+      variant={variant}
+      className={cn(className)}
+      data-widget-id={modelId}
+      data-widget-type="ToggleButton"
+    >
+      {icon && <span className="mr-1">{icon}</span>}
+      {description || "Toggle"}
+    </Toggle>
+  );
+}
+
+export default ToggleButtonWidget;

--- a/registry/widgets/controls/toggle-buttons-widget.tsx
+++ b/registry/widgets/controls/toggle-buttons-widget.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * ToggleButtons widget - renders a group of toggle buttons (single selection).
+ *
+ * Maps to ipywidgets ToggleButtonsModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { ToggleGroup, ToggleGroupItem } from "@/registry/primitives/toggle-group";
+import { Label } from "@/registry/primitives/label";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+import type { WidgetComponentProps } from "../widget-registry";
+
+export function ToggleButtonsWidget({
+  modelId,
+  className,
+}: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const options =
+    useWidgetModelValue<string[]>(modelId, "_options_labels") ?? [];
+  const index = useWidgetModelValue<number | null>(modelId, "index");
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const icons = useWidgetModelValue<string[]>(modelId, "icons") ?? [];
+  const tooltips = useWidgetModelValue<string[]>(modelId, "tooltips") ?? [];
+
+  // Convert index to string value for ToggleGroup
+  const value =
+    index !== null && index !== undefined && index >= 0
+      ? String(index)
+      : undefined;
+
+  const handleValueChange = (newValue: string) => {
+    if (newValue === "") {
+      // Deselection - ToggleButtons typically require a selection
+      return;
+    }
+    const newIndex = parseInt(newValue, 10);
+    if (!isNaN(newIndex)) {
+      sendUpdate(modelId, { index: newIndex });
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="ToggleButtons"
+    >
+      {description && (
+        <Label className="shrink-0 text-sm">{description}</Label>
+      )}
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={handleValueChange}
+        disabled={disabled}
+        variant="outline"
+      >
+        {options.map((option, idx) => (
+          <ToggleGroupItem
+            key={idx}
+            value={String(idx)}
+            title={tooltips[idx] || undefined}
+            disabled={disabled}
+          >
+            {icons[idx] && <span className="mr-1">{icons[idx]}</span>}
+            {option}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+}
+
+export default ToggleButtonsWidget;


### PR DESCRIPTION
## Summary

Implements built-in React components for ipywidgets selection controls, continuing work from #63.

- Added shadcn primitives: `select`, `radio-group`, `toggle`, `toggle-group`
- Implemented 5 new widget components mapping to ipywidgets models
- All widgets follow established pattern with `useWidgetModelValue` for state subscriptions and `sendUpdate` for kernel communication

## Widgets Added

- `DropdownWidget` → `DropdownModel` (Select)
- `RadioButtonsWidget` → `RadioButtonsModel` (RadioGroup)
- `ToggleButtonWidget` → `ToggleButtonModel` (Toggle)
- `ToggleButtonsWidget` → `ToggleButtonsModel` (ToggleGroup)
- `SelectMultipleWidget` → `SelectMultipleModel` (Custom Listbox)

TypeScript builds without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)