### PR TITLE
Document @nteract registry configuration

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -20,6 +20,25 @@ Install components directly from the registry using the shadcn CLI:
 npx shadcn@latest add https://nteract-elements.vercel.app/r/ansi-output.json
 ```
 
+### Using the `@nteract` namespace
+
+To use shorter install commands like `npx shadcn@latest add @nteract/badge`, add the registry to your `components.json`:
+
+```json
+{
+  "registries": {
+    "@nteract": "https://nteract-elements.vercel.app/r/{name}.json"
+  }
+}
+```
+
+Then install components with the `@nteract/` prefix:
+
+```bash
+npx shadcn@latest add @nteract/ansi-output
+npx shadcn@latest add @nteract/media-router
+```
+
 Or browse the component documentation to copy and adapt components for your project.
 
 ## Outputs


### PR DESCRIPTION
## Summary

- Add documentation for configuring the `registries` field in `components.json`
- Explain the `{name}` placeholder requirement
- Show both direct URL and namespace-prefixed installation methods

## Context

Users were getting "Invalid configuration" errors when adding the registries field without the `{name}` placeholder. The shadcn CLI schema requires URLs to include this placeholder.

## Related

- Fixes #79
- Supports PR shadcn-ui/ui#9550 (pending @nteract namespace registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)