### PR TITLE
Fix widget registry and enhance comm messages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -589,6 +589,32 @@
       ]
     },
     {
+      "name": "accordion",
+      "type": "registry:ui",
+      "title": "Accordion",
+      "description": "A vertically stacked set of interactive headings that reveal or hide associated content. Built on Radix UI.",
+      "dependencies": ["radix-ui", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/primitives/accordion.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "collapsible",
+      "type": "registry:ui",
+      "title": "Collapsible",
+      "description": "A component that can expand or collapse content. Built on Radix UI Collapsible primitive.",
+      "dependencies": ["radix-ui"],
+      "files": [
+        {
+          "path": "registry/primitives/collapsible.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "codemirror-editor",
       "type": "registry:component",
       "title": "CodeMirror Editor",
@@ -636,7 +662,7 @@
       "name": "widget-store",
       "type": "registry:lib",
       "title": "Widget Store",
-      "description": "Pure React state management for Jupyter widget models. Handles comm_open, comm_msg, and comm_close messages with fine-grained subscriptions via useSyncExternalStore.",
+      "description": "Pure React state management for Jupyter widget models. Handles comm_open, comm_msg, and comm_close messages with fine-grained subscriptions via useSyncExternalStore. Includes comm protocol router and buffer utilities.",
       "files": [
         {
           "path": "registry/widgets/widget-store.ts",
@@ -644,6 +670,14 @@
         },
         {
           "path": "registry/widgets/widget-store-context.tsx",
+          "type": "registry:lib"
+        },
+        {
+          "path": "registry/widgets/use-comm-router.ts",
+          "type": "registry:lib"
+        },
+        {
+          "path": "registry/widgets/buffer-utils.ts",
           "type": "registry:lib"
         }
       ]
@@ -682,8 +716,8 @@
       "name": "widget-controls",
       "type": "registry:component",
       "title": "Widget Controls",
-      "description": "Built-in shadcn-backed widget components for standard ipywidgets (IntSlider, FloatSlider, IntProgress, Button, Checkbox, Text, Textarea, Dropdown, RadioButtons, ToggleButton, ToggleButtons, SelectMultiple).",
-      "registryDependencies": ["@nteract/widget-view", "slider", "progress", "button", "checkbox", "input", "textarea", "label", "select", "radio-group", "toggle", "toggle-group"],
+      "description": "Built-in shadcn-backed widget components for standard ipywidgets including controls (IntSlider, FloatSlider, IntProgress, Button, Checkbox, Text, Textarea, Dropdown, RadioButtons, ToggleButton, ToggleButtons, SelectMultiple) and layout containers (VBox, HBox, Box, GridBox, Accordion, Tab).",
+      "registryDependencies": ["@nteract/widget-view", "slider", "progress", "button", "checkbox", "input", "textarea", "label", "select", "radio-group", "toggle", "toggle-group", "accordion", "tabs"],
       "files": [
         {
           "path": "registry/widgets/controls/index.ts",
@@ -739,6 +773,30 @@
         },
         {
           "path": "registry/widgets/controls/toggle-buttons-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/vbox-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/hbox-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/box-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/gridbox-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/accordion-widget.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/widgets/controls/tab-widget.tsx",
           "type": "registry:component"
         }
       ]

--- a/registry/widgets/use-comm-router.ts
+++ b/registry/widgets/use-comm-router.ts
@@ -6,7 +6,11 @@
  * Handles routing of Jupyter comm messages between the kernel and widget store.
  * Provides both inbound message handling and outbound message construction.
  *
+ * Message format follows the Jupyter messaging protocol specification and is
+ * compatible with strongly-typed backends (Rust, Go) that require explicit fields.
+ *
  * @see https://jupyter-widgets.readthedocs.io/en/latest/examples/Widget%20Low%20Level.html
+ * @see https://jupyter-client.readthedocs.io/en/latest/messaging.html
  */
 
 import { useCallback } from "react";
@@ -15,6 +19,10 @@ import { applyBufferPaths } from "./buffer-utils";
 
 // === Message Types ===
 
+/**
+ * Jupyter message header.
+ * Required fields vary between incoming (may have fewer) and outgoing (should have all).
+ */
 export interface JupyterMessageHeader {
   msg_id: string;
   msg_type: string;
@@ -24,9 +32,26 @@ export interface JupyterMessageHeader {
   version?: string;
 }
 
+/**
+ * Full header with all fields required (for outgoing messages).
+ */
+interface FullJupyterMessageHeader {
+  msg_id: string;
+  msg_type: string;
+  username: string;
+  session: string;
+  date: string;
+  version: string;
+}
+
+/**
+ * Jupyter comm message.
+ * Some fields are optional for incoming messages but should be set for outgoing.
+ */
 export interface JupyterCommMessage {
   header: JupyterMessageHeader;
-  parent_header?: JupyterMessageHeader;
+  /** Should be null for outgoing messages (not undefined or empty object) */
+  parent_header?: JupyterMessageHeader | null;
   metadata?: Record<string, unknown>;
   content: {
     comm_id?: string;
@@ -44,6 +69,27 @@ export interface JupyterCommMessage {
 }
 
 /**
+ * Outgoing message with all fields populated for protocol compliance.
+ * Use this type for messages being sent to strongly-typed backends.
+ */
+interface OutgoingJupyterCommMessage {
+  header: FullJupyterMessageHeader;
+  parent_header: null;
+  metadata: Record<string, unknown>;
+  content: {
+    comm_id: string;
+    data?: {
+      state?: Record<string, unknown>;
+      method?: string;
+      content?: Record<string, unknown>;
+      buffer_paths: string[][];
+    };
+  };
+  buffers: ArrayBuffer[];
+  channel: string;
+}
+
+/**
  * Function type for sending messages to the kernel.
  */
 export type SendMessage = (msg: JupyterCommMessage) => void;
@@ -55,6 +101,8 @@ export interface UseCommRouterOptions {
   sendMessage: SendMessage;
   /** Widget store instance */
   store: WidgetStore;
+  /** Optional username for message headers (default: "frontend") */
+  username?: string;
 }
 
 export interface UseCommRouterReturn {
@@ -78,66 +126,92 @@ export interface UseCommRouterReturn {
 
 // === Message Construction Helpers ===
 
+// Session ID for this frontend instance (stable across messages)
+const SESSION_ID = crypto.randomUUID();
+
+/**
+ * Create a complete Jupyter message header with all fields.
+ * All fields are required for compatibility with strongly-typed backends.
+ */
+function createHeader(msgType: string, username: string): FullJupyterMessageHeader {
+  return {
+    msg_id: crypto.randomUUID(),
+    msg_type: msgType,
+    username,
+    session: SESSION_ID,
+    date: new Date().toISOString(),
+    version: "5.3",
+  };
+}
+
 /**
  * Create a comm_msg for state updates.
+ * Includes all required fields for Jupyter protocol compliance.
  */
 function createUpdateMessage(
   commId: string,
   state: Record<string, unknown>,
-  buffers?: ArrayBuffer[]
-): JupyterCommMessage {
+  buffers: ArrayBuffer[] | undefined,
+  username: string
+): OutgoingJupyterCommMessage {
   return {
-    header: {
-      msg_id: crypto.randomUUID(),
-      msg_type: "comm_msg",
-    },
+    header: createHeader("comm_msg", username),
+    parent_header: null,
+    metadata: {},
     content: {
       comm_id: commId,
       data: {
         method: "update",
         state,
+        buffer_paths: [],
       },
     },
-    buffers,
+    buffers: buffers ?? [],
+    channel: "shell",
   };
 }
 
 /**
  * Create a comm_msg for custom messages.
+ * Includes all required fields for Jupyter protocol compliance.
  */
 function createCustomMessage(
   commId: string,
   content: Record<string, unknown>,
-  buffers?: ArrayBuffer[]
-): JupyterCommMessage {
+  buffers: ArrayBuffer[] | undefined,
+  username: string
+): OutgoingJupyterCommMessage {
   return {
-    header: {
-      msg_id: crypto.randomUUID(),
-      msg_type: "comm_msg",
-    },
+    header: createHeader("comm_msg", username),
+    parent_header: null,
+    metadata: {},
     content: {
       comm_id: commId,
       data: {
         method: "custom",
         content,
+        buffer_paths: [],
       },
     },
-    buffers,
+    buffers: buffers ?? [],
+    channel: "shell",
   };
 }
 
 /**
  * Create a comm_close message.
+ * Includes all required fields for Jupyter protocol compliance.
  */
-function createCloseMessage(commId: string): JupyterCommMessage {
+function createCloseMessage(commId: string, username: string): OutgoingJupyterCommMessage {
   return {
-    header: {
-      msg_id: crypto.randomUUID(),
-      msg_type: "comm_close",
-    },
+    header: createHeader("comm_close", username),
+    parent_header: null,
+    metadata: {},
     content: {
       comm_id: commId,
     },
+    buffers: [],
+    channel: "shell",
   };
 }
 
@@ -165,6 +239,7 @@ function createCloseMessage(commId: string): JupyterCommMessage {
 export function useCommRouter({
   sendMessage,
   store,
+  username = "frontend",
 }: UseCommRouterOptions): UseCommRouterReturn {
   /**
    * Handle incoming Jupyter comm messages.
@@ -183,7 +258,7 @@ export function useCommRouter({
           let state = msg.content.data?.state || {};
           const bufferPaths = msg.content.data?.buffer_paths;
 
-          if (bufferPaths && msg.buffers) {
+          if (bufferPaths && msg.buffers?.length) {
             state = { ...state };
             applyBufferPaths(state, bufferPaths, msg.buffers);
           }
@@ -201,7 +276,7 @@ export function useCommRouter({
             let state = data.state;
             const bufferPaths = data.buffer_paths;
 
-            if (bufferPaths && msg.buffers) {
+            if (bufferPaths && msg.buffers?.length) {
               state = { ...state };
               applyBufferPaths(state, bufferPaths, msg.buffers);
             }
@@ -237,9 +312,9 @@ export function useCommRouter({
       // Optimistic update: apply locally first for responsive UI
       store.updateModel(commId, state, buffers);
       // Then send to kernel
-      sendMessage(createUpdateMessage(commId, state, buffers));
+      sendMessage(createUpdateMessage(commId, state, buffers, username));
     },
-    [sendMessage, store]
+    [sendMessage, store, username]
   );
 
   /**
@@ -251,9 +326,9 @@ export function useCommRouter({
       content: Record<string, unknown>,
       buffers?: ArrayBuffer[]
     ) => {
-      sendMessage(createCustomMessage(commId, content, buffers));
+      sendMessage(createCustomMessage(commId, content, buffers, username));
     },
-    [sendMessage]
+    [sendMessage, username]
   );
 
   /**
@@ -262,10 +337,10 @@ export function useCommRouter({
    */
   const closeComm = useCallback(
     (commId: string) => {
-      sendMessage(createCloseMessage(commId));
+      sendMessage(createCloseMessage(commId, username));
       store.deleteModel(commId);
     },
-    [sendMessage, store]
+    [sendMessage, store, username]
   );
 
   return {


### PR DESCRIPTION
## Summary

Fixes critical registry issues that prevented CLI installation of widgets and enhances message format for strong type compatibility with Rust backends.

## Changes

- Add missing `use-comm-router.ts` and `buffer-utils.ts` to widget-store registry entry
- Add all layout widgets (VBox, HBox, Box, GridBox, Accordion, Tab) to registry
- Add `accordion` and `collapsible` primitives
- Enhance JupyterCommMessage format with full headers and explicit `parent_header: null`

## Context

Based on findings from runtimed/runtimed#221, where the sidecar team had to manually copy files because registry dependencies weren't resolving correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)