### PR TITLE
Use full URLs for registryDependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -92,12 +92,12 @@
       "title": "Media Router",
       "description": "MIME type-based output dispatcher that automatically selects the best renderer for Jupyter outputs. Supports custom renderers and priority ordering for platform-specific MIME types.",
       "registryDependencies": [
-        "@nteract/ansi-output",
-        "@nteract/markdown-output",
-        "@nteract/html-output",
-        "@nteract/image-output",
-        "@nteract/svg-output",
-        "@nteract/json-output"
+        "https://nteract-elements.vercel.app/r/ansi-output.json",
+        "https://nteract-elements.vercel.app/r/markdown-output.json",
+        "https://nteract-elements.vercel.app/r/html-output.json",
+        "https://nteract-elements.vercel.app/r/image-output.json",
+        "https://nteract-elements.vercel.app/r/svg-output.json",
+        "https://nteract-elements.vercel.app/r/json-output.json"
       ],
       "files": [
         {
@@ -138,7 +138,7 @@
       "title": "ButtonGroup",
       "description": "Group buttons together with merged borders. Includes ButtonGroupSeparator and ButtonGroupText.",
       "dependencies": ["@radix-ui/react-slot", "class-variance-authority"],
-      "registryDependencies": ["@nteract/separator"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/separator.json"],
       "files": [
         {
           "path": "registry/primitives/button-group.tsx",
@@ -254,7 +254,7 @@
       "title": "Dialog",
       "description": "A modal dialog component for confirmations, forms, and focused interactions. Includes overlay, header, footer, and close button.",
       "dependencies": ["radix-ui", "lucide-react"],
-      "registryDependencies": ["@nteract/button"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/button.json"],
       "files": [
         {
           "path": "registry/primitives/dialog.tsx",
@@ -293,7 +293,7 @@
       "title": "CellTypeButton",
       "description": "Styled buttons for different notebook cell types with color coding. Includes CodeCellButton, MarkdownCellButton, SqlCellButton, and AiCellButton convenience components.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["@nteract/button"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/button.json"],
       "files": [
         {
           "path": "registry/cell/CellTypeButton.tsx",
@@ -306,7 +306,7 @@
       "type": "registry:component",
       "title": "ExecutionStatus",
       "description": "A badge component that displays the execution state of a notebook cell. Shows queued, running, or error states.",
-      "registryDependencies": ["@nteract/badge"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/badge.json"],
       "files": [
         {
           "path": "registry/cell/ExecutionStatus.tsx",
@@ -346,7 +346,7 @@
       "title": "CellControls",
       "description": "Cell action menu with source visibility toggle, move controls, and dropdown menu for delete and clear operations.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["@nteract/button", "@nteract/dropdown-menu"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/button.json", "https://nteract-elements.vercel.app/r/dropdown-menu.json"],
       "files": [
         {
           "path": "registry/cell/CellControls.tsx",
@@ -410,7 +410,7 @@
       "title": "OutputArea",
       "description": "Wrapper component for rendering multiple Jupyter outputs with collapsible state and scroll behavior.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["@nteract/media-router", "@nteract/ansi-output"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/media-router.json", "https://nteract-elements.vercel.app/r/ansi-output.json"],
       "files": [
         {
           "path": "registry/cell/OutputArea.tsx",
@@ -462,7 +462,7 @@
       "title": "Command",
       "description": "A command palette component for keyboard-driven navigation and actions. Built on cmdk with dialog support.",
       "dependencies": ["cmdk", "lucide-react"],
-      "registryDependencies": ["@nteract/dialog"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/dialog.json"],
       "files": [
         {
           "path": "registry/primitives/command.tsx",
@@ -489,7 +489,7 @@
       "title": "CellTypeSelector",
       "description": "A dropdown selector for changing cell types in notebook interfaces. Supports filtering available types and displays the current type with color-coded styling.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["@nteract/button", "@nteract/dropdown-menu", "@nteract/cell-type-button"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/button.json", "https://nteract-elements.vercel.app/r/dropdown-menu.json", "https://nteract-elements.vercel.app/r/cell-type-button.json"],
       "files": [
         {
           "path": "registry/cell/CellTypeSelector.tsx",
@@ -502,7 +502,7 @@
       "type": "registry:component",
       "title": "CollaboratorAvatars",
       "description": "Display avatars of users collaborating on a notebook with overflow handling.",
-      "registryDependencies": ["@nteract/avatar", "@nteract/hover-card"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/avatar.json", "https://nteract-elements.vercel.app/r/hover-card.json"],
       "files": [
         {
           "path": "registry/cell/CollaboratorAvatars.tsx",
@@ -515,7 +515,7 @@
       "type": "registry:component",
       "title": "PresenceBookmarks",
       "description": "Shows stacked user avatars indicating who is present on a cell. Displays a HoverCard with user details and a +N overflow indicator when users exceed the limit.",
-      "registryDependencies": ["@nteract/avatar", "@nteract/hover-card"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/avatar.json", "https://nteract-elements.vercel.app/r/hover-card.json"],
       "files": [
         {
           "path": "registry/cell/PresenceBookmarks.tsx",
@@ -580,7 +580,7 @@
       "title": "Alert Dialog",
       "description": "A modal dialog for critical confirmations that require user acknowledgment. Built on Radix UI with accessible focus management.",
       "dependencies": ["radix-ui"],
-      "registryDependencies": ["@nteract/button"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/button.json"],
       "files": [
         {
           "path": "registry/primitives/alert-dialog.tsx",
@@ -687,7 +687,7 @@
       "type": "registry:component",
       "title": "AnyWidget View",
       "description": "React component for rendering anywidget ESM modules with the AFM (AnyWidget Frontend Module) interface. Handles dynamic ESM loading, CSS injection, and two-way state synchronization.",
-      "registryDependencies": ["@nteract/widget-store"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/widget-store.json"],
       "files": [
         {
           "path": "registry/widgets/anywidget-view.tsx",
@@ -700,7 +700,7 @@
       "type": "registry:component",
       "title": "Widget View",
       "description": "Universal widget router that renders Jupyter widgets. Routes anywidgets to ESM loader and standard ipywidgets to built-in shadcn-backed components.",
-      "registryDependencies": ["@nteract/widget-store", "@nteract/anywidget-view"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/widget-store.json", "https://nteract-elements.vercel.app/r/anywidget-view.json"],
       "files": [
         {
           "path": "registry/widgets/widget-view.tsx",
@@ -717,7 +717,7 @@
       "type": "registry:component",
       "title": "Widget Controls",
       "description": "Built-in shadcn-backed widget components for standard ipywidgets including controls (IntSlider, FloatSlider, IntProgress, Button, Checkbox, Text, Textarea, Dropdown, RadioButtons, ToggleButton, ToggleButtons, SelectMultiple) and layout containers (VBox, HBox, Box, GridBox, Accordion, Tab).",
-      "registryDependencies": ["@nteract/widget-view", "slider", "progress", "button", "checkbox", "input", "textarea", "label", "select", "radio-group", "toggle", "toggle-group", "accordion", "tabs"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/widget-view.json", "slider", "progress", "button", "checkbox", "input", "textarea", "label", "select", "radio-group", "toggle", "toggle-group", "accordion", "tabs"],
       "files": [
         {
           "path": "registry/widgets/controls/index.ts",
@@ -870,7 +870,7 @@
       "title": "Toggle Group",
       "description": "Toggle button group component built on Radix UI ToggleGroup primitive.",
       "dependencies": ["radix-ui", "class-variance-authority"],
-      "registryDependencies": ["@nteract/toggle"],
+      "registryDependencies": ["https://nteract-elements.vercel.app/r/toggle.json"],
       "files": [
         {
           "path": "registry/primitives/toggle-group.tsx",


### PR DESCRIPTION
## Summary

Replaces `@nteract/` prefixed registryDependencies with full registry URLs so components can be installed via CLI without configuration errors.

## Problem

The shadcn CLI doesn't support the `registries` config in `components.json`. When users tried to install `widget-controls` or other components with `@nteract/` dependencies, they got "Invalid configuration" errors.

## Solution

Replace all `@nteract/component-name` references with `https://nteract-elements.vercel.app/r/component-name.json`.

Now this works:
```bash
npx shadcn@latest add https://nteract-elements.vercel.app/r/widget-controls.json -y
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)