### PR TITLE
Fix send() content wrapping and buffer types for anywidgets

### DIFF
--- a/registry/widgets/anywidget-view.tsx
+++ b/registry/widgets/anywidget-view.tsx
@@ -306,6 +306,7 @@ export function createAFMModelProxy(
     ): void {
       // Send custom message to kernel
       // Full Jupyter protocol message format for strongly-typed backends
+      // Note: ipywidgets expects content to be nested in data.content, not spread
       sendMessage({
         header: createHeader("comm_msg"),
         parent_header: null,
@@ -314,9 +315,8 @@ export function createAFMModelProxy(
           comm_id: model.id,
           data: {
             method: "custom",
-            ...content,
-            buffer_paths: [],
-          } as Record<string, unknown>,
+            content: content, // Wrap content properly for ipywidgets protocol
+          },
         },
         buffers: buffers ?? [],
         channel: "shell",


### PR DESCRIPTION
## Summary

Two critical fixes for anywidget compatibility, discovered during sidecar integration:

1. **Fix `send()` content wrapping** - ipywidgets expects custom message content to be nested in `data.content`, not spread into `data`
2. **Fix buffer types** - Callbacks now receive `DataView[]` instead of `ArrayBuffer[]`, matching JupyterLab services behavior. Anywidgets access the underlying buffer via `.buffer` property.

## Changes

**anywidget-view.tsx:**
- `send()` now wraps content: `data: { method: "custom", content: content }` instead of spreading

**widget-store.ts:**
- `CustomMessageCallback` type changed from `ArrayBuffer[]` to `DataView[]`
- `emitCustomMessage` converts buffers to DataView before passing to callbacks

## Test plan

- [ ] Test with quak widget - should load and render data table
- [ ] Test `model.send()` dispatches SQL queries to kernel correctly
- [ ] Test `model.on("msg:custom")` receives buffers that can access `.buffer`

## References

- ipywidgets widget.py expects `data['content']`: https://github.com/jupyter-widgets/ipywidgets/blob/main/python/ipywidgets/ipywidgets/widgets/widget.py#L766
- JupyterLab services deserializes buffers as DataView: https://github.com/jupyterlab/jupyterlab/blob/main/packages/services/src/kernel/serialize.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)