### PR TITLE
Fix tqdm progress bar styling in HBox layouts

### DIFF
--- a/app/components/WidgetControlsGallery.tsx
+++ b/app/components/WidgetControlsGallery.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
 import {
   type JupyterCommMessage,
   useWidgetModels,
@@ -350,6 +351,22 @@ const CONTAINER_SETUP = {
       name: "CheckboxModel",
       state: { value: false, description: "Panel 2 option" },
     },
+    // tqdm-like progress bar children (matches actual tqdm output format)
+    {
+      id: "tqdm-label",
+      name: "HTMLModel",
+      state: { value: "Downloading model.safetensors:  42%" },
+    },
+    {
+      id: "tqdm-progress",
+      name: "FloatProgressModel",
+      state: { value: 42, min: 0, max: 100, bar_style: "success" },
+    },
+    {
+      id: "tqdm-stats",
+      name: "HTMLModel",
+      state: { value: " 1.2G/2.8G [00:19&lt;00:26, 62.1MB/s]" },
+    },
   ],
   containers: [
     {
@@ -406,6 +423,19 @@ const CONTAINER_SETUP = {
         children: ["IPY_MODEL_container-acc-1", "IPY_MODEL_container-acc-2"],
         _titles: ["Expandable Panel 1", "Expandable Panel 2"],
         selected_index: 0,
+      },
+    },
+    {
+      id: "gallery-tqdm",
+      name: "HBoxModel",
+      label: "tqdm-style Progress",
+      span: 2, // Full width to show progress bar properly
+      state: {
+        children: [
+          "IPY_MODEL_tqdm-label",
+          "IPY_MODEL_tqdm-progress",
+          "IPY_MODEL_tqdm-stats",
+        ],
       },
     },
   ],
@@ -488,7 +518,10 @@ function GalleryContent() {
           {CONTAINER_SETUP.containers.map((container) => (
             <div
               key={container.id}
-              className="border rounded-lg p-4 bg-background"
+              className={cn(
+                "border rounded-lg p-4 bg-background",
+                container.span === 2 && "md:col-span-2",
+              )}
             >
               <div className="text-xs font-mono text-muted-foreground mb-3">
                 {container.label}

--- a/registry/widgets/controls/float-progress.tsx
+++ b/registry/widgets/controls/float-progress.tsx
@@ -39,18 +39,13 @@ export function FloatProgress({ modelId, className }: WidgetComponentProps) {
     danger: "[&>[data-slot=progress-indicator]]:bg-red-500",
   };
 
-  // Format value for display
-  const formatValue = (v: number): string => {
-    return v.toFixed(2);
-  };
-
   const isVertical = orientation === "vertical";
 
   return (
     <div
       className={cn(
         "flex gap-3",
-        isVertical ? "flex-col items-center" : "items-center",
+        isVertical ? "flex-col items-center" : "flex-1 items-center",
         className,
       )}
       data-widget-id={modelId}
@@ -64,9 +59,6 @@ export function FloatProgress({ modelId, className }: WidgetComponentProps) {
           barStyle && barStyleClasses[barStyle],
         )}
       />
-      <span className="w-16 text-right tabular-nums text-sm text-muted-foreground">
-        {formatValue(value)}
-      </span>
     </div>
   );
 }

--- a/registry/widgets/controls/html-widget.tsx
+++ b/registry/widgets/controls/html-widget.tsx
@@ -21,7 +21,7 @@ export function HTMLWidget({ modelId, className }: WidgetComponentProps) {
 
   return (
     <div
-      className={cn("flex items-start gap-3", className)}
+      className={cn("flex shrink-0 items-start gap-3", className)}
       data-widget-id={modelId}
       data-widget-type="HTML"
     >

--- a/registry/widgets/controls/int-progress.tsx
+++ b/registry/widgets/controls/int-progress.tsx
@@ -45,7 +45,7 @@ export function IntProgress({ modelId, className }: WidgetComponentProps) {
     <div
       className={cn(
         "flex gap-3",
-        isVertical ? "flex-col items-center" : "items-center",
+        isVertical ? "flex-col items-center" : "flex-1 items-center",
         className,
       )}
       data-widget-id={modelId}
@@ -59,9 +59,6 @@ export function IntProgress({ modelId, className }: WidgetComponentProps) {
           barStyle && barStyleClasses[barStyle],
         )}
       />
-      <span className="w-12 text-right tabular-nums text-sm text-muted-foreground">
-        {value}
-      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes tqdm progress bars appearing wonky with:
- Progress bars too short/narrow compared to text labels
- Stray numeric values (e.g., "20.00") displayed incorrectly
- HBox children not expanding properly

## Changes

- Add `flex-1` to FloatProgress and IntProgress wrappers for horizontal layout to expand and fill available space
- Remove numeric value readout from progress bars (matches ipywidgets behavior, tqdm handles display via HTML widgets)
- Add `shrink-0` to HTMLWidget to prevent label compression
- Add tqdm-style progress demo to widget gallery

## Testing

Run `pnpm dev` and navigate to the widgets docs page. The "Layout Containers" section now includes a "tqdm-style Progress" example showing proper layout and spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)