### PR TITLE
Use baseline alignment for HBox and HTMLWidget

### DIFF
--- a/registry/widgets/controls/hbox-widget.tsx
+++ b/registry/widgets/controls/hbox-widget.tsx
@@ -35,7 +35,7 @@ export function HBoxWidget({ modelId, className }: WidgetComponentProps) {
   return (
     <div
       className={cn(
-        "flex flex-row flex-wrap items-start gap-2",
+        "flex flex-row flex-wrap items-baseline gap-1",
         styleClass,
         className,
       )}

--- a/registry/widgets/controls/html-widget.tsx
+++ b/registry/widgets/controls/html-widget.tsx
@@ -21,7 +21,7 @@ export function HTMLWidget({ modelId, className }: WidgetComponentProps) {
 
   return (
     <div
-      className={cn("flex shrink-0 items-start gap-3", className)}
+      className={cn("inline-flex shrink-0 items-baseline gap-1", className)}
       data-widget-id={modelId}
       data-widget-type="HTML"
     >


### PR DESCRIPTION
## Summary

Follow-up to #93 - Improves text alignment in HBox layouts to match JupyterLab's `widget-inline-hbox` pattern.

## Changes

- **HBox**: `items-start gap-2` → `items-baseline gap-1`
- **HTMLWidget**: `flex items-start gap-3` → `inline-flex items-baseline gap-1`

## Result

tqdm progress bars now have proper text baseline alignment - labels and stats align correctly with the progress bar instead of being top-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)