### PR TITLE
Track closed widgets to fix leave=False progress bars

### DIFF
--- a/registry/widgets/widget-store-context.tsx
+++ b/registry/widgets/widget-store-context.tsx
@@ -216,6 +216,18 @@ export function useResolvedModelValue<T = unknown>(
   return resolved as T | WidgetModel | undefined;
 }
 
+/**
+ * Check if a widget model was explicitly closed (e.g., tqdm with leave=False).
+ * Returns true if the model was closed, false if it never existed or is active.
+ *
+ * Note: This hook is not reactive on its own. It relies on being used alongside
+ * useWidgetModel, which subscribes to store changes and triggers re-renders.
+ */
+export function useWasWidgetClosed(modelId: string): boolean {
+  const { store } = useWidgetStoreRequired();
+  return store.wasModelClosed(modelId);
+}
+
 export type {
   JupyterCommMessage,
   JupyterMessageHeader,

--- a/registry/widgets/widget-view.tsx
+++ b/registry/widgets/widget-view.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 import { AnyWidgetView, isAnyWidget } from "./anywidget-view";
 import { getWidgetComponent } from "./widget-registry";
 import type { WidgetModel } from "./widget-store";
-import { useWidgetModel } from "./widget-store-context";
+import { useWasWidgetClosed, useWidgetModel } from "./widget-store-context";
 
 // === Props ===
 
@@ -76,8 +76,14 @@ function UnsupportedWidget({ model, className }: UnsupportedWidgetProps) {
  */
 export function WidgetView({ modelId, className }: WidgetViewProps) {
   const model = useWidgetModel(modelId);
+  const wasClosed = useWasWidgetClosed(modelId);
 
-  // Model not loaded yet
+  // Model was explicitly closed (e.g., tqdm with leave=False) - render nothing
+  if (wasClosed) {
+    return null;
+  }
+
+  // Model not loaded yet - show loading state
   if (!model) {
     return <LoadingWidget modelId={modelId} className={className} />;
   }


### PR DESCRIPTION
## Summary

Fixes tqdm progress bars with `leave=False` rendering "Loading widget..." indefinitely. When nested progress bars complete, they send `comm_close` which removes the model from the store, but the `display_data` output cell still references it, causing the widget view to show a loading state that will never resolve.

## Changes

- Add `closedModels` Set to widget store to track explicitly closed models
- Implement `wasModelClosed()` method to distinguish closed widgets from never-created ones
- Update `WidgetView` to render nothing for closed widgets instead of `LoadingWidget`
- Handle widget re-open edge case by removing from closed set in `createModel`

## Testing

Verified with the tqdm nested progress bar example:
```python
from tqdm.auto import tqdm
import time

for filename in tqdm(["a.txt", "b.txt", "c.txt"]):
    for _ in tqdm(range(100), leave=False):
        time.sleep(0.01)
```
Inner bars disappear cleanly when complete. Type checks and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)