### PR TITLE
Add 9 new ipywidget models

### DIFF
--- a/app/components/WidgetControlsGallery.tsx
+++ b/app/components/WidgetControlsGallery.tsx
@@ -138,7 +138,7 @@ const WIDGET_CATEGORIES = {
   },
   text: {
     title: "Text Input",
-    description: "Text and HTML content",
+    description: "Text input fields",
     widgets: [
       {
         id: "gallery-text",
@@ -162,12 +162,101 @@ const WIDGET_CATEGORIES = {
         },
       },
       {
+        id: "gallery-password",
+        name: "PasswordModel",
+        label: "Password",
+        state: {
+          value: "",
+          description: "Secret:",
+          placeholder: "Enter password...",
+        },
+      },
+    ],
+  },
+  numeric: {
+    title: "Numeric Input",
+    description: "Number input fields",
+    widgets: [
+      {
+        id: "gallery-int-text",
+        name: "IntTextModel",
+        label: "IntText",
+        state: {
+          value: 42,
+          description: "Count:",
+          step: 1,
+        },
+      },
+      {
+        id: "gallery-float-text",
+        name: "FloatTextModel",
+        label: "FloatText",
+        state: {
+          value: 3.14,
+          description: "Value:",
+          step: 0.1,
+        },
+      },
+      {
+        id: "gallery-bounded-int-text",
+        name: "BoundedIntTextModel",
+        label: "BoundedIntText",
+        state: {
+          value: 50,
+          min: 0,
+          max: 100,
+          step: 5,
+          description: "Bounded:",
+        },
+      },
+      {
+        id: "gallery-bounded-float-text",
+        name: "BoundedFloatTextModel",
+        label: "BoundedFloatText",
+        state: {
+          value: 0.5,
+          min: 0,
+          max: 1,
+          step: 0.05,
+          description: "Ratio:",
+        },
+      },
+    ],
+  },
+  display: {
+    title: "Display",
+    description: "Output and display widgets",
+    widgets: [
+      {
+        id: "gallery-label",
+        name: "LabelModel",
+        label: "Label",
+        state: {
+          value: "Plain text display",
+          description: "Status:",
+        },
+      },
+      {
         id: "gallery-html",
         name: "HTMLModel",
         label: "HTML",
         state: {
           value: "<strong>Bold</strong> and <em>italic</em> text",
           description: "Output:",
+        },
+      },
+      {
+        id: "gallery-image",
+        name: "ImageModel",
+        label: "Image",
+        state: {
+          // Small 2x2 red PNG image (base64)
+          value:
+            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAADklEQVQIW2P4z8DwHwAFAAH/q842AAAAAElFTkSuQmCC",
+          format: "png",
+          width: "64px",
+          height: "64px",
+          description: "Preview:",
         },
       },
     ],
@@ -212,6 +301,17 @@ const WIDGET_CATEGORIES = {
         },
       },
       {
+        id: "gallery-select",
+        name: "SelectModel",
+        label: "Select",
+        state: {
+          index: 1,
+          _options_labels: ["First", "Second", "Third", "Fourth"],
+          description: "Pick one:",
+          rows: 4,
+        },
+      },
+      {
         id: "gallery-radio",
         name: "RadioButtonsModel",
         label: "RadioButtons",
@@ -237,7 +337,7 @@ const WIDGET_CATEGORIES = {
         name: "SelectMultipleModel",
         label: "SelectMultiple",
         state: {
-          value: ["Item 2"],
+          index: [1],
           _options_labels: ["Item 1", "Item 2", "Item 3", "Item 4"],
           description: "Select many:",
           rows: 4,
@@ -247,7 +347,7 @@ const WIDGET_CATEGORIES = {
   },
   other: {
     title: "Other Controls",
-    description: "Buttons and color picker",
+    description: "Buttons, color picker, and validation",
     widgets: [
       {
         id: "gallery-button",
@@ -267,6 +367,26 @@ const WIDGET_CATEGORIES = {
           value: "#3b82f6",
           description: "Color:",
           concise: false,
+        },
+      },
+      {
+        id: "gallery-valid",
+        name: "ValidModel",
+        label: "Valid",
+        state: {
+          value: true,
+          description: "Status:",
+          readout: "All checks passed",
+        },
+      },
+      {
+        id: "gallery-invalid",
+        name: "ValidModel",
+        label: "Valid (invalid)",
+        state: {
+          value: false,
+          description: "Status:",
+          readout: "Validation failed",
         },
       },
     ],

--- a/content/docs/widgets/controls.mdx
+++ b/content/docs/widgets/controls.mdx
@@ -68,9 +68,31 @@ import { IntSlider, Button, VBox } from "@/lib/controls"
 |--------|------------|-------------|
 | Text | `TextModel` | Single-line text input |
 | Textarea | `TextareaModel` | Multi-line text input |
-| HTML | `HTMLModel` | Rendered HTML content |
+| Password | `PasswordModel` | Masked text input |
 
-**Common props:** `value`, `description`, `placeholder`, `disabled`
+**Common props:** `value`, `description`, `placeholder`, `disabled`, `continuous_update`
+
+### Numeric Input
+
+| Widget | Model Name | Description |
+|--------|------------|-------------|
+| IntText | `IntTextModel` | Integer text input |
+| FloatText | `FloatTextModel` | Float text input |
+| BoundedIntText | `BoundedIntTextModel` | Bounded integer text input |
+| BoundedFloatText | `BoundedFloatTextModel` | Bounded float text input |
+
+**Common props:** `value`, `min`, `max`, `step`, `description`, `disabled`, `continuous_update`
+
+### Display
+
+| Widget | Model Name | Description |
+|--------|------------|-------------|
+| Label | `LabelModel` | Plain text display |
+| HTML | `HTMLModel` | Rendered HTML content |
+| Image | `ImageModel` | Image display from kernel |
+
+**Label/HTML props:** `value`, `description`, `placeholder`
+**Image props:** `value` (base64), `format`, `width`, `height`, `description`
 
 ### Boolean
 
@@ -86,11 +108,12 @@ import { IntSlider, Button, VBox } from "@/lib/controls"
 | Widget | Model Name | Description |
 |--------|------------|-------------|
 | Dropdown | `DropdownModel` | Single-select dropdown |
+| Select | `SelectModel` | Single-select listbox |
 | RadioButtons | `RadioButtonsModel` | Radio button group |
 | ToggleButtons | `ToggleButtonsModel` | Button group for selection |
 | SelectMultiple | `SelectMultipleModel` | Multi-select listbox |
 
-**Common props:** `value`, `_options_labels`, `description`, `disabled`
+**Common props:** `index`, `_options_labels`, `description`, `disabled`, `rows`
 
 ### Other
 
@@ -98,9 +121,11 @@ import { IntSlider, Button, VBox } from "@/lib/controls"
 |--------|------------|-------------|
 | Button | `ButtonModel` | Clickable button |
 | ColorPicker | `ColorPickerModel` | Color selection input |
+| Valid | `ValidModel` | Validation indicator (checkmark/X) |
 
 **Button props:** `description` (button text), `button_style`, `tooltip`, `disabled`
 **ColorPicker props:** `value` (hex color), `description`, `concise`, `disabled`
+**Valid props:** `value` (boolean), `readout` (status message), `description`
 
 ### Layout Containers
 

--- a/registry/widgets/controls/bounded-float-text-widget.tsx
+++ b/registry/widgets/controls/bounded-float-text-widget.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * BoundedFloatText widget - renders a bounded numeric text input for floats.
+ *
+ * Maps to ipywidgets BoundedFloatTextModel.
+ * This is functionally the same as FloatText since both support min/max bounds.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/registry/primitives/input";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+export function BoundedFloatTextWidget({
+  modelId,
+  className,
+}: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const value = useWidgetModelValue<number>(modelId, "value") ?? 0;
+  const min = useWidgetModelValue<number>(modelId, "min") ?? 0;
+  const max = useWidgetModelValue<number>(modelId, "max") ?? 100;
+  const step = useWidgetModelValue<number>(modelId, "step") ?? 0.1;
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const continuousUpdate =
+    useWidgetModelValue<boolean>(modelId, "continuous_update") ?? false;
+
+  // Local state for the input value (as string for editing)
+  const [localValue, setLocalValue] = useState(String(value));
+
+  // Sync local state when value changes from kernel
+  useEffect(() => {
+    setLocalValue(String(value));
+  }, [value]);
+
+  const clampValue = useCallback(
+    (val: number): number => {
+      return Math.max(min, Math.min(max, val));
+    },
+    [min, max],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setLocalValue(newValue);
+
+      if (continuousUpdate) {
+        const parsed = parseFloat(newValue);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, continuousUpdate, clampValue, sendUpdate],
+  );
+
+  const handleBlur = useCallback(() => {
+    const parsed = parseFloat(localValue);
+    if (!Number.isNaN(parsed)) {
+      const clamped = clampValue(parsed);
+      setLocalValue(String(clamped));
+      if (clamped !== value) {
+        sendUpdate(modelId, { value: clamped });
+      }
+    } else {
+      // Reset to current value if invalid
+      setLocalValue(String(value));
+    }
+  }, [modelId, localValue, value, clampValue, sendUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        const parsed = parseFloat(localValue);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          setLocalValue(String(clamped));
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, localValue, clampValue, sendUpdate],
+  );
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="BoundedFloatText"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      <Input
+        type="number"
+        value={localValue}
+        disabled={disabled}
+        step={step}
+        min={min}
+        max={max}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="w-24"
+      />
+    </div>
+  );
+}
+
+export default BoundedFloatTextWidget;

--- a/registry/widgets/controls/bounded-int-text-widget.tsx
+++ b/registry/widgets/controls/bounded-int-text-widget.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * BoundedIntText widget - renders a bounded numeric text input for integers.
+ *
+ * Maps to ipywidgets BoundedIntTextModel.
+ * This is functionally the same as IntText since both support min/max bounds.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/registry/primitives/input";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+export function BoundedIntTextWidget({
+  modelId,
+  className,
+}: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const value = useWidgetModelValue<number>(modelId, "value") ?? 0;
+  const min = useWidgetModelValue<number>(modelId, "min") ?? 0;
+  const max = useWidgetModelValue<number>(modelId, "max") ?? 100;
+  const step = useWidgetModelValue<number>(modelId, "step") ?? 1;
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const continuousUpdate =
+    useWidgetModelValue<boolean>(modelId, "continuous_update") ?? false;
+
+  // Local state for the input value (as string for editing)
+  const [localValue, setLocalValue] = useState(String(value));
+
+  // Sync local state when value changes from kernel
+  useEffect(() => {
+    setLocalValue(String(value));
+  }, [value]);
+
+  const clampValue = useCallback(
+    (val: number): number => {
+      return Math.max(min, Math.min(max, val));
+    },
+    [min, max],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setLocalValue(newValue);
+
+      if (continuousUpdate) {
+        const parsed = parseInt(newValue, 10);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, continuousUpdate, clampValue, sendUpdate],
+  );
+
+  const handleBlur = useCallback(() => {
+    const parsed = parseInt(localValue, 10);
+    if (!Number.isNaN(parsed)) {
+      const clamped = clampValue(parsed);
+      setLocalValue(String(clamped));
+      if (clamped !== value) {
+        sendUpdate(modelId, { value: clamped });
+      }
+    } else {
+      // Reset to current value if invalid
+      setLocalValue(String(value));
+    }
+  }, [modelId, localValue, value, clampValue, sendUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        const parsed = parseInt(localValue, 10);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          setLocalValue(String(clamped));
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, localValue, clampValue, sendUpdate],
+  );
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="BoundedIntText"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      <Input
+        type="number"
+        value={localValue}
+        disabled={disabled}
+        step={step}
+        min={min}
+        max={max}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="w-24"
+      />
+    </div>
+  );
+}
+
+export default BoundedIntTextWidget;

--- a/registry/widgets/controls/float-text-widget.tsx
+++ b/registry/widgets/controls/float-text-widget.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * FloatText widget - renders a numeric text input for floats.
+ *
+ * Maps to ipywidgets FloatTextModel.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/registry/primitives/input";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+export function FloatTextWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const value = useWidgetModelValue<number>(modelId, "value") ?? 0;
+  const min = useWidgetModelValue<number>(modelId, "min");
+  const max = useWidgetModelValue<number>(modelId, "max");
+  const step = useWidgetModelValue<number>(modelId, "step") ?? 0.1;
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const continuousUpdate =
+    useWidgetModelValue<boolean>(modelId, "continuous_update") ?? false;
+
+  // Local state for the input value (as string for editing)
+  const [localValue, setLocalValue] = useState(String(value));
+
+  // Sync local state when value changes from kernel
+  useEffect(() => {
+    setLocalValue(String(value));
+  }, [value]);
+
+  const clampValue = useCallback(
+    (val: number): number => {
+      let clamped = val;
+      if (min !== undefined && min !== null) {
+        clamped = Math.max(min, clamped);
+      }
+      if (max !== undefined && max !== null) {
+        clamped = Math.min(max, clamped);
+      }
+      return clamped;
+    },
+    [min, max],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setLocalValue(newValue);
+
+      if (continuousUpdate) {
+        const parsed = parseFloat(newValue);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, continuousUpdate, clampValue, sendUpdate],
+  );
+
+  const handleBlur = useCallback(() => {
+    const parsed = parseFloat(localValue);
+    if (!Number.isNaN(parsed)) {
+      const clamped = clampValue(parsed);
+      setLocalValue(String(clamped));
+      if (clamped !== value) {
+        sendUpdate(modelId, { value: clamped });
+      }
+    } else {
+      // Reset to current value if invalid
+      setLocalValue(String(value));
+    }
+  }, [modelId, localValue, value, clampValue, sendUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        const parsed = parseFloat(localValue);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          setLocalValue(String(clamped));
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, localValue, clampValue, sendUpdate],
+  );
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="FloatText"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      <Input
+        type="number"
+        value={localValue}
+        disabled={disabled}
+        step={step}
+        min={min}
+        max={max}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="w-24"
+      />
+    </div>
+  );
+}
+
+export default FloatTextWidget;

--- a/registry/widgets/controls/image-widget.tsx
+++ b/registry/widgets/controls/image-widget.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * Image widget - displays images from the kernel.
+ *
+ * Maps to ipywidgets ImageModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+
+export function ImageWidget({ modelId, className }: WidgetComponentProps) {
+  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const format = useWidgetModelValue<string>(modelId, "format") ?? "png";
+  const width = useWidgetModelValue<string>(modelId, "width") ?? "";
+  const height = useWidgetModelValue<string>(modelId, "height") ?? "";
+  const description = useWidgetModelValue<string>(modelId, "description");
+
+  if (!value) {
+    return null;
+  }
+
+  // Construct data URL from base64 value
+  // If already a data URL or regular URL, use as-is
+  const src =
+    value.startsWith("data:") ||
+    value.startsWith("http://") ||
+    value.startsWith("https://") ||
+    value.startsWith("/")
+      ? value
+      : `data:image/${format};base64,${value}`;
+
+  // Build style object for width/height
+  const style: React.CSSProperties = {};
+  if (width) style.width = width;
+  if (height) style.height = height;
+
+  return (
+    <div
+      className={cn("inline-flex items-start gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="Image"
+    >
+      {description && (
+        <Label className="shrink-0 pt-1 text-sm">{description}</Label>
+      )}
+      <img
+        src={src}
+        alt={description || "Widget image"}
+        className="block max-w-full h-auto"
+        style={{ objectFit: "contain", ...style }}
+      />
+    </div>
+  );
+}
+
+export default ImageWidget;

--- a/registry/widgets/controls/index.ts
+++ b/registry/widgets/controls/index.ts
@@ -7,6 +7,8 @@
 
 import { registerWidget } from "../widget-registry";
 import { AccordionWidget } from "./accordion-widget";
+import { BoundedFloatTextWidget } from "./bounded-float-text-widget";
+import { BoundedIntTextWidget } from "./bounded-int-text-widget";
 import { BoxWidget } from "./box-widget";
 import { ButtonWidget } from "./button-widget";
 import { CheckboxWidget } from "./checkbox-widget";
@@ -16,20 +18,27 @@ import { DropdownWidget } from "./dropdown-widget";
 import { FloatProgress } from "./float-progress";
 import { FloatRangeSlider } from "./float-range-slider";
 import { FloatSlider } from "./float-slider";
+import { FloatTextWidget } from "./float-text-widget";
 import { GridBoxWidget } from "./gridbox-widget";
 import { HBoxWidget } from "./hbox-widget";
 import { HTMLWidget } from "./html-widget";
+import { ImageWidget } from "./image-widget";
 import { IntProgress } from "./int-progress";
 import { IntRangeSlider } from "./int-range-slider";
 // Import widget components
 import { IntSlider } from "./int-slider";
+import { IntTextWidget } from "./int-text-widget";
+import { LabelWidget } from "./label-widget";
+import { PasswordWidget } from "./password-widget";
 import { RadioButtonsWidget } from "./radio-buttons-widget";
 import { SelectMultipleWidget } from "./select-multiple-widget";
+import { SelectWidget } from "./select-widget";
 import { TabWidget } from "./tab-widget";
 import { TextWidget } from "./text-widget";
 import { TextareaWidget } from "./textarea-widget";
 import { ToggleButtonWidget } from "./toggle-button-widget";
 import { ToggleButtonsWidget } from "./toggle-buttons-widget";
+import { ValidWidget } from "./valid-widget";
 // Import layout widget components
 import { VBoxWidget } from "./vbox-widget";
 
@@ -45,10 +54,20 @@ registerWidget("CheckboxModel", CheckboxWidget);
 registerWidget("TextModel", TextWidget);
 registerWidget("TextareaModel", TextareaWidget);
 registerWidget("HTMLModel", HTMLWidget);
+registerWidget("LabelModel", LabelWidget);
+registerWidget("ImageModel", ImageWidget);
 registerWidget("ColorPickerModel", ColorPicker);
+// Numeric text inputs
+registerWidget("IntTextModel", IntTextWidget);
+registerWidget("FloatTextModel", FloatTextWidget);
+registerWidget("BoundedIntTextModel", BoundedIntTextWidget);
+registerWidget("BoundedFloatTextModel", BoundedFloatTextWidget);
+registerWidget("PasswordModel", PasswordWidget);
+registerWidget("ValidModel", ValidWidget);
 // Selection widgets
 registerWidget("DropdownModel", DropdownWidget);
 registerWidget("RadioButtonsModel", RadioButtonsWidget);
+registerWidget("SelectModel", SelectWidget);
 registerWidget("SelectMultipleModel", SelectMultipleWidget);
 registerWidget("ToggleButtonModel", ToggleButtonWidget);
 registerWidget("ToggleButtonsModel", ToggleButtonsWidget);
@@ -62,6 +81,8 @@ registerWidget("AccordionModel", AccordionWidget);
 registerWidget("TabModel", TabWidget);
 
 export { AccordionWidget } from "./accordion-widget";
+export { BoundedFloatTextWidget } from "./bounded-float-text-widget";
+export { BoundedIntTextWidget } from "./bounded-int-text-widget";
 export { BoxWidget } from "./box-widget";
 export { ButtonWidget } from "./button-widget";
 export { CheckboxWidget } from "./checkbox-widget";
@@ -71,19 +92,26 @@ export { DropdownWidget } from "./dropdown-widget";
 export { FloatProgress } from "./float-progress";
 export { FloatRangeSlider } from "./float-range-slider";
 export { FloatSlider } from "./float-slider";
+export { FloatTextWidget } from "./float-text-widget";
 export { GridBoxWidget } from "./gridbox-widget";
 export { HBoxWidget } from "./hbox-widget";
 export { HTMLWidget } from "./html-widget";
+export { ImageWidget } from "./image-widget";
 export { IntProgress } from "./int-progress";
 export { IntRangeSlider } from "./int-range-slider";
 // Re-export components for direct use
 export { IntSlider } from "./int-slider";
+export { IntTextWidget } from "./int-text-widget";
+export { LabelWidget } from "./label-widget";
+export { PasswordWidget } from "./password-widget";
 export { RadioButtonsWidget } from "./radio-buttons-widget";
 export { SelectMultipleWidget } from "./select-multiple-widget";
+export { SelectWidget } from "./select-widget";
 export { TabWidget } from "./tab-widget";
 export { TextWidget } from "./text-widget";
 export { TextareaWidget } from "./textarea-widget";
 export { ToggleButtonWidget } from "./toggle-button-widget";
 export { ToggleButtonsWidget } from "./toggle-buttons-widget";
+export { ValidWidget } from "./valid-widget";
 // Re-export layout widgets
 export { VBoxWidget } from "./vbox-widget";

--- a/registry/widgets/controls/int-text-widget.tsx
+++ b/registry/widgets/controls/int-text-widget.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * IntText widget - renders a numeric text input for integers.
+ *
+ * Maps to ipywidgets IntTextModel.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/registry/primitives/input";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+export function IntTextWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const value = useWidgetModelValue<number>(modelId, "value") ?? 0;
+  const min = useWidgetModelValue<number>(modelId, "min");
+  const max = useWidgetModelValue<number>(modelId, "max");
+  const step = useWidgetModelValue<number>(modelId, "step") ?? 1;
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const continuousUpdate =
+    useWidgetModelValue<boolean>(modelId, "continuous_update") ?? false;
+
+  // Local state for the input value (as string for editing)
+  const [localValue, setLocalValue] = useState(String(value));
+
+  // Sync local state when value changes from kernel
+  useEffect(() => {
+    setLocalValue(String(value));
+  }, [value]);
+
+  const clampValue = useCallback(
+    (val: number): number => {
+      let clamped = val;
+      if (min !== undefined && min !== null) {
+        clamped = Math.max(min, clamped);
+      }
+      if (max !== undefined && max !== null) {
+        clamped = Math.min(max, clamped);
+      }
+      return clamped;
+    },
+    [min, max],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setLocalValue(newValue);
+
+      if (continuousUpdate) {
+        const parsed = parseInt(newValue, 10);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, continuousUpdate, clampValue, sendUpdate],
+  );
+
+  const handleBlur = useCallback(() => {
+    const parsed = parseInt(localValue, 10);
+    if (!Number.isNaN(parsed)) {
+      const clamped = clampValue(parsed);
+      setLocalValue(String(clamped));
+      if (clamped !== value) {
+        sendUpdate(modelId, { value: clamped });
+      }
+    } else {
+      // Reset to current value if invalid
+      setLocalValue(String(value));
+    }
+  }, [modelId, localValue, value, clampValue, sendUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        const parsed = parseInt(localValue, 10);
+        if (!Number.isNaN(parsed)) {
+          const clamped = clampValue(parsed);
+          setLocalValue(String(clamped));
+          sendUpdate(modelId, { value: clamped });
+        }
+      }
+    },
+    [modelId, localValue, clampValue, sendUpdate],
+  );
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="IntText"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      <Input
+        type="number"
+        value={localValue}
+        disabled={disabled}
+        step={step}
+        min={min}
+        max={max}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="w-24"
+      />
+    </div>
+  );
+}
+
+export default IntTextWidget;

--- a/registry/widgets/controls/label-widget.tsx
+++ b/registry/widgets/controls/label-widget.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * Label widget - renders plain text content.
+ *
+ * Maps to ipywidgets LabelModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+
+export function LabelWidget({ modelId, className }: WidgetComponentProps) {
+  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const placeholder = useWidgetModelValue<string>(modelId, "placeholder");
+
+  // Show placeholder if value is empty
+  const displayValue = value || placeholder || "";
+
+  return (
+    <div
+      className={cn("inline-flex shrink-0 items-baseline gap-1", className)}
+      data-widget-id={modelId}
+      data-widget-type="Label"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      <span className="widget-label-content">{displayValue}</span>
+    </div>
+  );
+}
+
+export default LabelWidget;

--- a/registry/widgets/controls/password-widget.tsx
+++ b/registry/widgets/controls/password-widget.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Password widget - renders a masked text input field.
+ *
+ * Maps to ipywidgets PasswordModel.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/registry/primitives/input";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+export function PasswordWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate, sendCustom } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const placeholder = useWidgetModelValue<string>(modelId, "placeholder") ?? "";
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const continuousUpdate =
+    useWidgetModelValue<boolean>(modelId, "continuous_update") ?? true;
+
+  // Local state for non-continuous updates
+  const [localValue, setLocalValue] = useState(value);
+
+  // Sync local state when value changes from kernel
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setLocalValue(newValue);
+
+      if (continuousUpdate) {
+        sendUpdate(modelId, { value: newValue });
+      }
+    },
+    [modelId, continuousUpdate, sendUpdate],
+  );
+
+  const handleBlur = useCallback(() => {
+    if (!continuousUpdate && localValue !== value) {
+      sendUpdate(modelId, { value: localValue });
+    }
+  }, [modelId, continuousUpdate, localValue, value, sendUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        // Send submit event
+        sendCustom(modelId, { event: "submit" });
+        // Also ensure value is synced
+        if (!continuousUpdate && localValue !== value) {
+          sendUpdate(modelId, { value: localValue });
+        }
+      }
+    },
+    [modelId, continuousUpdate, localValue, value, sendUpdate, sendCustom],
+  );
+
+  return (
+    <div
+      className={cn("flex items-center gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="Password"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      <Input
+        type="password"
+        value={localValue}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="flex-1"
+      />
+    </div>
+  );
+}
+
+export default PasswordWidget;

--- a/registry/widgets/controls/select-widget.tsx
+++ b/registry/widgets/controls/select-widget.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * Select widget - renders a single-selection listbox.
+ *
+ * Maps to ipywidgets SelectModel.
+ */
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+export function SelectWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate } = useWidgetStoreRequired();
+
+  // Subscribe to individual state keys
+  const options =
+    useWidgetModelValue<string[]>(modelId, "_options_labels") ?? [];
+  const selectedIndex = useWidgetModelValue<number | null>(modelId, "index");
+  const description = useWidgetModelValue<string>(modelId, "description");
+  const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
+  const rows = useWidgetModelValue<number>(modelId, "rows") ?? 5;
+
+  const handleSelect = (idx: number) => {
+    if (disabled) return;
+    sendUpdate(modelId, { index: idx });
+  };
+
+  // Calculate height based on rows
+  const itemHeight = 32; // approximate height per item in px
+  const maxHeight = rows * itemHeight;
+
+  return (
+    <div
+      className={cn("flex items-start gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="Select"
+    >
+      {description && (
+        <Label className="shrink-0 pt-1 text-sm">{description}</Label>
+      )}
+      <div
+        role="listbox"
+        aria-disabled={disabled}
+        className={cn(
+          "w-48 overflow-y-auto rounded-md border border-input bg-background shadow-xs",
+          disabled && "cursor-not-allowed opacity-50",
+        )}
+        style={{ maxHeight }}
+      >
+        {options.map((option, idx) => {
+          const isSelected = selectedIndex === idx;
+          return (
+            <div
+              key={idx}
+              role="option"
+              aria-selected={isSelected}
+              onClick={() => handleSelect(idx)}
+              className={cn(
+                "flex cursor-pointer select-none items-center px-3 py-1.5 text-sm",
+                "hover:bg-accent hover:text-accent-foreground",
+                isSelected && "bg-accent text-accent-foreground",
+                disabled && "pointer-events-none",
+              )}
+            >
+              <span>{option}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default SelectWidget;

--- a/registry/widgets/controls/valid-widget.tsx
+++ b/registry/widgets/controls/valid-widget.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * Valid widget - displays a validation indicator (checkmark or X).
+ *
+ * Maps to ipywidgets ValidModel.
+ */
+
+import { CheckIcon, XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Label } from "@/registry/primitives/label";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+
+export function ValidWidget({ modelId, className }: WidgetComponentProps) {
+  const value = useWidgetModelValue<boolean>(modelId, "value") ?? false;
+  const readout = useWidgetModelValue<string>(modelId, "readout") ?? "";
+  const description = useWidgetModelValue<string>(modelId, "description");
+
+  return (
+    <div
+      className={cn("inline-flex items-center gap-2", className)}
+      data-widget-id={modelId}
+      data-widget-type="Valid"
+    >
+      {description && <Label className="shrink-0 text-sm">{description}</Label>}
+      {value ? (
+        <CheckIcon className="size-4 text-green-500" />
+      ) : (
+        <XIcon className="size-4 text-red-500" />
+      )}
+      {readout && (
+        <span className="text-sm text-muted-foreground">{readout}</span>
+      )}
+    </div>
+  );
+}
+
+export default ValidWidget;


### PR DESCRIPTION
## Summary

Implements 9 new ipywidget models to expand widget coverage: LabelModel, ImageModel, PasswordModel, ValidModel, IntTextModel, FloatTextModel, BoundedIntTextModel, BoundedFloatTextModel, and SelectModel. All follow the existing widget pattern and are registered in the controls registry.

Widget count increases from 22 to 31. Updated controls documentation with reference tables and added live interactive demos to the gallery.

## Test plan

- Type checking: `pnpm types:check` ✓
- Linting: `pnpm lint` ✓
- Build: `pnpm build` ✓
- Gallery: All 9 new widgets render with interactive demos at `/docs/widgets/controls`

Closes #91