### PR TITLE
Add missing shadcn primitives to widget-controls dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -750,7 +750,10 @@
         "toggle",
         "toggle-group",
         "accordion",
-        "tabs"
+        "tabs",
+        "command",
+        "popover",
+        "badge"
       ],
       "files": [
         {


### PR DESCRIPTION
## Summary

The combobox-widget and tags-input-widget components import command, popover, and badge primitives, but these were not declared as registryDependencies for widget-controls. This causes the shadcn CLI to transform import paths incorrectly when users install via npx shadcn add.

## Changes

Added command, popover, and badge to the widget-controls registryDependencies in registry.json.

Closes #101