### PR TITLE
Host registry.json and add all bundle component

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "scripts": {
-    "build": "shadcn build && next build",
+    "build": "shadcn build && cp registry.json public/r/registry.json && next build",
     "dev": "next dev",
     "start": "next start",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",

--- a/registry.json
+++ b/registry.json
@@ -1069,6 +1069,30 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "all",
+      "type": "registry:component",
+      "title": "All nteract Components",
+      "description": "Install all Jupyter frontend components: outputs, cell primitives, widgets, and editor.",
+      "registryDependencies": [
+        "@nteract/media-router",
+        "@nteract/output-area",
+        "@nteract/cell-container",
+        "@nteract/cell-header",
+        "@nteract/cell-controls",
+        "@nteract/cell-type-button",
+        "@nteract/cell-type-selector",
+        "@nteract/execution-count",
+        "@nteract/execution-status",
+        "@nteract/play-button",
+        "@nteract/runtime-health-indicator",
+        "@nteract/collaborator-avatars",
+        "@nteract/presence-bookmarks",
+        "@nteract/widget-controls",
+        "@nteract/codemirror-editor"
+      ],
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enable registry discoverability and add convenient bundle installation:
- Serve registry.json at `/r/registry.json` for LLMs and tools
- Add `@nteract/all` bundle to install all components at once
- No breaking changes, purely additive

## Test plan

- Build succeeds: `pnpm run build`
- Registry index accessible: `curl http://localhost:3000/r/registry.json`
- Bundle component accessible: `curl http://localhost:3000/r/all.json`

🤖 Generated with Claude Code