### PR TITLE
Point primitive dependencies to upstream shadcn

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -138,7 +138,7 @@
       "title": "ButtonGroup",
       "description": "Group buttons together with merged borders. Includes ButtonGroupSeparator and ButtonGroupText.",
       "dependencies": ["@radix-ui/react-slot", "class-variance-authority"],
-      "registryDependencies": ["@nteract/separator"],
+      "registryDependencies": ["separator"],
       "files": [
         {
           "path": "registry/primitives/button-group.tsx",
@@ -254,7 +254,7 @@
       "title": "Dialog",
       "description": "A modal dialog component for confirmations, forms, and focused interactions. Includes overlay, header, footer, and close button.",
       "dependencies": ["radix-ui", "lucide-react"],
-      "registryDependencies": ["@nteract/button"],
+      "registryDependencies": ["button"],
       "files": [
         {
           "path": "registry/primitives/dialog.tsx",
@@ -293,7 +293,7 @@
       "title": "CellTypeButton",
       "description": "Styled buttons for different notebook cell types with color coding. Includes CodeCellButton, MarkdownCellButton, SqlCellButton, and AiCellButton convenience components.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["@nteract/button"],
+      "registryDependencies": ["button"],
       "files": [
         {
           "path": "registry/cell/CellTypeButton.tsx",
@@ -306,7 +306,7 @@
       "type": "registry:component",
       "title": "ExecutionStatus",
       "description": "A badge component that displays the execution state of a notebook cell. Shows queued, running, or error states.",
-      "registryDependencies": ["@nteract/badge"],
+      "registryDependencies": ["badge"],
       "files": [
         {
           "path": "registry/cell/ExecutionStatus.tsx",
@@ -346,7 +346,7 @@
       "title": "CellControls",
       "description": "Cell action menu with source visibility toggle, move controls, and dropdown menu for delete and clear operations.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["@nteract/button", "@nteract/dropdown-menu"],
+      "registryDependencies": ["button", "dropdown-menu"],
       "files": [
         {
           "path": "registry/cell/CellControls.tsx",
@@ -462,7 +462,7 @@
       "title": "Command",
       "description": "A command palette component for keyboard-driven navigation and actions. Built on cmdk with dialog support.",
       "dependencies": ["cmdk", "lucide-react"],
-      "registryDependencies": ["@nteract/dialog"],
+      "registryDependencies": ["dialog"],
       "files": [
         {
           "path": "registry/primitives/command.tsx",
@@ -490,8 +490,8 @@
       "description": "A dropdown selector for changing cell types in notebook interfaces. Supports filtering available types and displays the current type with color-coded styling.",
       "dependencies": ["lucide-react"],
       "registryDependencies": [
-        "@nteract/button",
-        "@nteract/dropdown-menu",
+        "button",
+        "dropdown-menu",
         "@nteract/cell-type-button"
       ],
       "files": [
@@ -506,7 +506,7 @@
       "type": "registry:component",
       "title": "CollaboratorAvatars",
       "description": "Display avatars of users collaborating on a notebook with overflow handling.",
-      "registryDependencies": ["@nteract/avatar", "@nteract/hover-card"],
+      "registryDependencies": ["avatar", "hover-card"],
       "files": [
         {
           "path": "registry/cell/CollaboratorAvatars.tsx",
@@ -519,7 +519,7 @@
       "type": "registry:component",
       "title": "PresenceBookmarks",
       "description": "Shows stacked user avatars indicating who is present on a cell. Displays a HoverCard with user details and a +N overflow indicator when users exceed the limit.",
-      "registryDependencies": ["@nteract/avatar", "@nteract/hover-card"],
+      "registryDependencies": ["avatar", "hover-card"],
       "files": [
         {
           "path": "registry/cell/PresenceBookmarks.tsx",
@@ -584,7 +584,7 @@
       "title": "Alert Dialog",
       "description": "A modal dialog for critical confirmations that require user acknowledgment. Built on Radix UI with accessible focus management.",
       "dependencies": ["radix-ui"],
-      "registryDependencies": ["@nteract/button"],
+      "registryDependencies": ["button"],
       "files": [
         {
           "path": "registry/primitives/alert-dialog.tsx",
@@ -1062,7 +1062,7 @@
       "title": "Toggle Group",
       "description": "Toggle button group component built on Radix UI ToggleGroup primitive.",
       "dependencies": ["radix-ui", "class-variance-authority"],
-      "registryDependencies": ["@nteract/toggle"],
+      "registryDependencies": ["toggle"],
       "files": [
         {
           "path": "registry/primitives/toggle-group.tsx",


### PR DESCRIPTION
## Summary

Update 11 components to use upstream shadcn primitives instead of @nteract copies. Resolves dependency duplication and simplifies registry maintenance.

## Changes

- button-group, dialog, command: separator, button, dialog
- cell-type-button, execution-status, cell-controls: button, badge, dropdown-menu
- collaborator-avatars, presence-bookmarks: avatar, hover-card  
- alert-dialog, toggle-group: button, toggle

Keeps Jupyter-specific components (@nteract/cell-type-button) namespaced. Part of Stage 2 registry cleanup.

🤖 Generated with Claude Code