### PR TITLE
Fix consumer-facing import paths in documentation

### DIFF
--- a/content/docs/cell/cell-container.mdx
+++ b/content/docs/cell/cell-container.mdx
@@ -38,12 +38,12 @@ CellContainer          <- Focus wrapper with selection border
 Here's how to compose a complete cell:
 
 ```tsx
-import { CellContainer } from "@/registry/cell/CellContainer";
-import { CellHeader } from "@/registry/cell/CellHeader";
-import { CellControls } from "@/registry/cell/CellControls";
-import { CellTypeButton } from "@/registry/cell/CellTypeButton";
-import { PlayButton } from "@/registry/cell/PlayButton";
-import { ExecutionStatus } from "@/registry/cell/ExecutionStatus";
+import { CellContainer } from "@/components/cell/CellContainer";
+import { CellHeader } from "@/components/cell/CellHeader";
+import { CellControls } from "@/components/cell/CellControls";
+import { CellTypeButton } from "@/components/cell/CellTypeButton";
+import { PlayButton } from "@/components/cell/PlayButton";
+import { ExecutionStatus } from "@/components/cell/ExecutionStatus";
 
 function NotebookCell({ cell, isFocused, onFocus }) {
   const [sourceVisible, setSourceVisible] = useState(true);

--- a/content/docs/cell/cell-controls.mdx
+++ b/content/docs/cell/cell-controls.mdx
@@ -36,7 +36,7 @@ By default, controls are hidden on desktop and shown on hover (always visible on
 ## Usage
 
 ```tsx
-import { CellControls } from "@/registry/cell/CellControls"
+import { CellControls } from "@/components/cell/CellControls"
 
 export function CellToolbar() {
   const [sourceVisible, setSourceVisible] = useState(true)
@@ -115,7 +115,7 @@ export function CellToolbar() {
 ### With PlayButton
 
 ```tsx
-import { PlayButton } from "@/registry/cell/PlayButton"
+import { PlayButton } from "@/components/cell/PlayButton"
 
 <CellControls
   sourceVisible={sourceVisible}

--- a/content/docs/cell/cell-header.mdx
+++ b/content/docs/cell/cell-header.mdx
@@ -36,7 +36,7 @@ A flexible header component for notebook cells that provides left and right cont
 ## Usage
 
 ```tsx
-import { CellHeader } from "@/registry/cell/CellHeader"
+import { CellHeader } from "@/components/cell/CellHeader"
 
 export function MyCell() {
   return (

--- a/content/docs/cell/cell-type-button.mdx
+++ b/content/docs/cell/cell-type-button.mdx
@@ -36,7 +36,7 @@ Styled buttons for different notebook cell types. Each cell type has a distinct 
 ## Usage
 
 ```tsx
-import { CellTypeButton, CodeCellButton, MarkdownCellButton } from "@/registry/cell/CellTypeButton"
+import { CellTypeButton, CodeCellButton, MarkdownCellButton } from "@/components/cell/CellTypeButton"
 
 export function Example() {
   return (

--- a/content/docs/cell/cell-type-selector.mdx
+++ b/content/docs/cell/cell-type-selector.mdx
@@ -33,7 +33,7 @@ A dropdown selector for changing cell types. Displays the current type with colo
 ## Usage
 
 ```tsx
-import { CellTypeSelector } from "@/registry/cell/CellTypeSelector"
+import { CellTypeSelector } from "@/components/cell/CellTypeSelector"
 
 export function Example() {
   const [cellType, setCellType] = useState<CellType>("code")

--- a/content/docs/cell/collaborator-avatars.mdx
+++ b/content/docs/cell/collaborator-avatars.mdx
@@ -40,7 +40,7 @@ The CollaboratorAvatars component displays a row of user avatars showing who is 
 ## Usage
 
 ```tsx
-import { CollaboratorAvatars } from "@/registry/cell/CollaboratorAvatars";
+import { CollaboratorAvatars } from "@/components/cell/CollaboratorAvatars";
 
 const users = [
   { id: "1", name: "Alice Smith", picture: "https://example.com/alice.jpg", color: "#e91e63" },
@@ -128,8 +128,8 @@ Colors can be used to indicate cursor positions or user-specific highlighting in
 ### In a Cell Header
 
 ```tsx
-import { CellHeader } from "@/registry/cell/CellHeader";
-import { CollaboratorAvatars } from "@/registry/cell/CollaboratorAvatars";
+import { CellHeader } from "@/components/cell/CellHeader";
+import { CollaboratorAvatars } from "@/components/cell/CollaboratorAvatars";
 
 <CellHeader
   leftContent={<PlayButton />}

--- a/content/docs/cell/execution-count.mdx
+++ b/content/docs/cell/execution-count.mdx
@@ -34,7 +34,7 @@ A cell primitive that displays the classic Jupyter execution count indicator. Us
 ## Usage
 
 ```tsx
-import { ExecutionCount } from "@/registry/cell/ExecutionCount"
+import { ExecutionCount } from "@/components/cell/ExecutionCount"
 
 export function CellGutter() {
   return (

--- a/content/docs/cell/execution-status.mdx
+++ b/content/docs/cell/execution-status.mdx
@@ -34,7 +34,7 @@ A cell primitive that displays the current execution state of a notebook cell. R
 ## Usage
 
 ```tsx
-import { ExecutionStatus } from "@/registry/cell/ExecutionStatus"
+import { ExecutionStatus } from "@/components/cell/ExecutionStatus"
 
 export function CellHeader() {
   return (

--- a/content/docs/cell/output-area.mdx
+++ b/content/docs/cell/output-area.mdx
@@ -35,7 +35,7 @@ OutputArea handles rendering multiple Jupyter outputs with:
 ## Usage
 
 ```tsx
-import { OutputArea } from "@/registry/cell/OutputArea"
+import { OutputArea } from "@/components/cell/OutputArea"
 
 export function CellWithOutputs({ cell }) {
   const [collapsed, setCollapsed] = useState(false)

--- a/content/docs/cell/play-button.mdx
+++ b/content/docs/cell/play-button.mdx
@@ -36,7 +36,7 @@ A button component for executing notebook cells. Shows different icons based on 
 ## Usage
 
 ```tsx
-import { PlayButton } from "@/registry/cell/PlayButton"
+import { PlayButton } from "@/components/cell/PlayButton"
 
 export function CellToolbar() {
   return (

--- a/content/docs/cell/presence-bookmarks.mdx
+++ b/content/docs/cell/presence-bookmarks.mdx
@@ -33,7 +33,7 @@ A component for displaying real-time presence indicators on notebook cells. Show
 ## Usage
 
 ```tsx
-import { PresenceBookmarks, type User } from "@/registry/cell/PresenceBookmarks"
+import { PresenceBookmarks, type User } from "@/components/cell/PresenceBookmarks"
 
 const users: User[] = [
   { id: "1", name: "Alice Chen", picture: "https://...", color: "#ef4444" },

--- a/content/docs/cell/runtime-health-indicator.mdx
+++ b/content/docs/cell/runtime-health-indicator.mdx
@@ -34,7 +34,7 @@ A component that displays kernel connection status with color-coded indicators. 
 ## Usage
 
 ```tsx
-import { RuntimeHealthIndicator } from "@/registry/cell/RuntimeHealthIndicator"
+import { RuntimeHealthIndicator } from "@/components/cell/RuntimeHealthIndicator"
 
 export function NotebookToolbar() {
   return (
@@ -131,7 +131,7 @@ import {
   getStatusText,
   getStatusTextColor,
   type RuntimeStatus
-} from "@/registry/cell/RuntimeHealthIndicator"
+} from "@/components/cell/RuntimeHealthIndicator"
 
 // Get the Tailwind color class for a status
 getStatusColor("idle") // "text-green-500"

--- a/content/docs/editor/codemirror-editor.mdx
+++ b/content/docs/editor/codemirror-editor.mdx
@@ -38,7 +38,7 @@ Try the editor above — switch languages, edit the code, and toggle between lig
 ## Usage
 
 ```tsx
-import { CodeMirrorEditor } from "@/registry/editor";
+import { CodeMirrorEditor } from "@/components/editor";
 
 export function MyCell() {
   const [source, setSource] = useState("print('Hello, world!')");
@@ -130,7 +130,7 @@ Force a specific theme:
 Access theme utilities directly:
 
 ```tsx
-import { lightTheme, darkTheme, isDarkMode } from "@/registry/editor";
+import { lightTheme, darkTheme, isDarkMode } from "@/components/editor";
 
 // Check current dark mode state
 if (isDarkMode()) {
@@ -215,7 +215,7 @@ import { lineNumbers } from "@codemirror/view";
 For AI prompt inputs or simpler use cases:
 
 ```tsx
-import { minimalExtensions } from "@/registry/editor";
+import { minimalExtensions } from "@/components/editor";
 
 <CodeMirrorEditor
   value={prompt}
@@ -232,7 +232,7 @@ import { minimalExtensions } from "@/registry/editor";
 Detect language from filename:
 
 ```tsx
-import { detectLanguage } from "@/registry/editor";
+import { detectLanguage } from "@/components/editor";
 
 const language = detectLanguage("script.py"); // "python"
 const language = detectLanguage("README.md"); // "markdown"
@@ -243,11 +243,11 @@ const language = detectLanguage("README.md"); // "markdown"
 Combine with cell components for a complete notebook cell:
 
 ```tsx
-import { CellContainer } from "@/registry/cell/CellContainer";
-import { CellHeader } from "@/registry/cell/CellHeader";
-import { PlayButton } from "@/registry/cell/PlayButton";
-import { CodeMirrorEditor } from "@/registry/editor";
-import { OutputArea } from "@/registry/cell/OutputArea";
+import { CellContainer } from "@/components/cell/CellContainer";
+import { CellHeader } from "@/components/cell/CellHeader";
+import { PlayButton } from "@/components/cell/PlayButton";
+import { CodeMirrorEditor } from "@/components/editor";
+import { OutputArea } from "@/components/cell/OutputArea";
 
 function CodeCell({ cell, outputs }) {
   const [source, setSource] = useState(cell.source);

--- a/content/docs/outputs/ansi-output.mdx
+++ b/content/docs/outputs/ansi-output.mdx
@@ -51,7 +51,7 @@ This package exports three components:
 The base component for rendering any text with ANSI escape sequences.
 
 ```tsx
-import { AnsiOutput } from "@/registry/outputs/ansi-output"
+import { AnsiOutput } from "@/components/outputs/ansi-output"
 
 export function Example() {
   const text = "\x1b[32mSuccess:\x1b[0m Operation completed"
@@ -83,7 +83,7 @@ Here's a more colorful example:
 Renders stdout or stderr output with appropriate styling.
 
 ```tsx
-import { AnsiStreamOutput } from "@/registry/outputs/ansi-output"
+import { AnsiStreamOutput } from "@/components/outputs/ansi-output"
 
 export function StreamExample() {
   return (
@@ -125,7 +125,7 @@ export function StreamExample() {
 Renders Python-style error tracebacks with proper formatting.
 
 ```tsx
-import { AnsiErrorOutput } from "@/registry/outputs/ansi-output"
+import { AnsiErrorOutput } from "@/components/outputs/ansi-output"
 
 export function ErrorExample() {
   return (

--- a/content/docs/outputs/html-output.mdx
+++ b/content/docs/outputs/html-output.mdx
@@ -27,7 +27,7 @@ Component for rendering HTML content in notebook outputs. Handles pandas DataFra
 ## Usage
 
 ```tsx
-import { HtmlOutput } from "@/registry/outputs/html-output"
+import { HtmlOutput } from "@/components/outputs/html-output"
 
 export function Example() {
   const html = "<table><tr><th>Name</th><th>Value</th></tr><tr><td>A</td><td>1</td></tr></table>"

--- a/content/docs/outputs/image-output.mdx
+++ b/content/docs/outputs/image-output.mdx
@@ -35,7 +35,7 @@ Component for rendering images in notebook outputs. Handles base64-encoded image
 ## Usage
 
 ```tsx
-import { ImageOutput } from "@/registry/outputs/image-output"
+import { ImageOutput } from "@/components/outputs/image-output"
 
 export function Example() {
   // Base64 encoded image data from Jupyter kernel
@@ -78,7 +78,7 @@ The component accepts image data in several formats:
 When working with Jupyter outputs, image data typically comes from `display_data` or `execute_result` messages:
 
 ```tsx
-import { ImageOutput } from "@/registry/outputs/image-output"
+import { ImageOutput } from "@/components/outputs/image-output"
 
 function renderOutput(output: JupyterOutput) {
   const data = output.data;

--- a/content/docs/outputs/json-output.mdx
+++ b/content/docs/outputs/json-output.mdx
@@ -44,7 +44,7 @@ Component for rendering JSON data in an interactive, expandable tree view. Usefu
 ## Usage
 
 ```tsx
-import { JsonOutput } from "@/registry/outputs/json-output"
+import { JsonOutput } from "@/components/outputs/json-output"
 
 export function Example() {
   const data = {
@@ -115,7 +115,7 @@ When receiving JSON as a string (e.g., from user input or text fields), parse it
 "use client";
 
 import { useState } from "react";
-import { JsonOutput } from "@/registry/outputs/json-output";
+import { JsonOutput } from "@/components/outputs/json-output";
 
 export function JsonStringViewer() {
   const [input, setInput] = useState('{"name": "example", "count": 42}');

--- a/content/docs/outputs/markdown-output.mdx
+++ b/content/docs/outputs/markdown-output.mdx
@@ -51,7 +51,7 @@ Component for rendering Markdown content in notebook outputs. Based on the [inth
 ## Usage
 
 ```tsx
-import { MarkdownOutput } from "@/registry/outputs/markdown-output"
+import { MarkdownOutput } from "@/components/outputs/markdown-output"
 
 export function Example() {
   const markdown = `# Title

--- a/content/docs/outputs/media-router.mdx
+++ b/content/docs/outputs/media-router.mdx
@@ -33,7 +33,7 @@ Automatically selects the best renderer for Jupyter outputs based on MIME type p
 ### Basic
 
 ```tsx
-import { MediaRouter } from "@/registry/outputs/media-router"
+import { MediaRouter } from "@/components/outputs/media-router"
 
 export function CellOutput({ output }) {
   return <MediaRouter data={output.data} metadata={output.metadata} />
@@ -60,7 +60,7 @@ Metadata is keyed by MIME type, same as data. Used for image dimensions, JSON di
 Register custom renderers for MIME types not supported by the built-ins, or override built-ins:
 
 ```tsx
-import { MediaRouter, DEFAULT_PRIORITY } from "@/registry/outputs/media-router"
+import { MediaRouter, DEFAULT_PRIORITY } from "@/components/outputs/media-router"
 import { PlotlyChart } from "./plotly-chart"
 import { VegaLiteChart } from "./vega-lite-chart"
 
@@ -125,7 +125,7 @@ Custom renderers receive their metadata directly and can use any keys.
 The default MIME type priority (higher = preferred):
 
 ```tsx
-import { DEFAULT_PRIORITY } from "@/registry/outputs/media-router"
+import { DEFAULT_PRIORITY } from "@/components/outputs/media-router"
 
 // DEFAULT_PRIORITY = [
 //   "application/vnd.jupyter.widget-view+json",
@@ -151,7 +151,7 @@ priority={["application/x-custom", ...DEFAULT_PRIORITY]}
 ## Jupyter Integration
 
 ```tsx
-import { MediaRouter } from "@/registry/outputs/media-router"
+import { MediaRouter } from "@/components/outputs/media-router"
 
 function CellOutput({ output }) {
   // execute_result and display_data outputs
@@ -183,7 +183,7 @@ For HTML and Markdown outputs that contain scripts, use `unsafe={true}`. This re
 Use `getSelectedMimeType` to inspect which MIME type would be selected:
 
 ```tsx
-import { getSelectedMimeType, DEFAULT_PRIORITY } from "@/registry/outputs/media-router"
+import { getSelectedMimeType, DEFAULT_PRIORITY } from "@/components/outputs/media-router"
 
 const mimeType = getSelectedMimeType(
   { "text/plain": "Hello", "text/html": "<b>Hello</b>" },

--- a/content/docs/outputs/svg-output.mdx
+++ b/content/docs/outputs/svg-output.mdx
@@ -26,7 +26,7 @@ Component for rendering SVG graphics in notebook outputs. Handles matplotlib fig
 ## Usage
 
 ```tsx
-import { SvgOutput } from "@/registry/outputs/svg-output"
+import { SvgOutput } from "@/components/outputs/svg-output"
 
 export function Example() {
   const svg = `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">

--- a/content/docs/widgets/anywidget-view.mdx
+++ b/content/docs/widgets/anywidget-view.mdx
@@ -44,7 +44,7 @@ React component for rendering [anywidget](https://anywidget.dev) ESM modules. Im
 ### Basic Usage
 
 ```tsx
-import { AnyWidgetView } from "@/registry/widgets/anywidget-view"
+import { AnyWidgetView } from "@/components/widgets/anywidget-view"
 
 function WidgetOutput({ modelId }: { modelId: string }) {
   return <AnyWidgetView modelId={modelId} />
@@ -56,8 +56,8 @@ function WidgetOutput({ modelId }: { modelId: string }) {
 The component requires `WidgetStoreProvider` to be present in the component tree:
 
 ```tsx
-import { WidgetStoreProvider } from "@/registry/widgets/widget-store-context"
-import { AnyWidgetView } from "@/registry/widgets/anywidget-view"
+import { WidgetStoreProvider } from "@/components/widgets/widget-store-context"
+import { AnyWidgetView } from "@/components/widgets/anywidget-view"
 
 function App() {
   return (
@@ -177,7 +177,7 @@ export default {
 Use `isAnyWidget` to check if a model is an anywidget:
 
 ```tsx
-import { isAnyWidget } from "@/registry/widgets/anywidget-view"
+import { isAnyWidget } from "@/components/widgets/anywidget-view"
 
 function WidgetRouter({ model }) {
   if (isAnyWidget(model)) {

--- a/content/docs/widgets/controls.mdx
+++ b/content/docs/widgets/controls.mdx
@@ -36,10 +36,10 @@ Import the controls module to register all built-in widgets:
 
 ```tsx
 // Import to register all built-in widgets
-import "@/lib/controls"
+import "@/components/widgets/controls"
 
 // Or import specific widgets
-import { IntSlider, Button, VBox } from "@/lib/controls"
+import { IntSlider, Button, VBox } from "@/components/widgets/controls"
 ```
 
 ## Widget Reference
@@ -187,8 +187,8 @@ import { IntSlider, Button, VBox } from "@/lib/controls"
 Register your own component to replace any built-in widget:
 
 ```tsx
-import { registerWidget } from "@/lib/widget-registry"
-import { useWidgetModelValue, useWidgetStoreRequired } from "@/lib/widget-store-context"
+import { registerWidget } from "@/components/widgets/widget-registry"
+import { useWidgetModelValue, useWidgetStoreRequired } from "@/components/widgets/widget-store-context"
 
 function MyFancySlider({ modelId, className }) {
   const { sendUpdate } = useWidgetStoreRequired()

--- a/content/docs/widgets/index.mdx
+++ b/content/docs/widgets/index.mdx
@@ -99,9 +99,9 @@ npx shadcn@latest add @nteract/widget-controls
 <RegistrySetup />
 
 ```tsx
-import { WidgetStoreProvider } from "@/lib/widget-store-context"
-import { WidgetView } from "@/lib/widget-view"
-import "@/lib/controls" // Register built-in widgets
+import { WidgetStoreProvider } from "@/components/widgets/widget-store-context"
+import { WidgetView } from "@/components/widgets/widget-view"
+import "@/components/widgets/controls" // Register built-in widgets
 
 function NotebookApp({ kernel }) {
   // Route kernel messages to the widget store
@@ -133,7 +133,7 @@ Every built-in widget uses shadcn/ui primitives. Customize them by:
 3. **Fork and modify** - Copy a widget file and adjust as needed
 
 ```tsx
-import { registerWidget } from "@/lib/widget-registry"
+import { registerWidget } from "@/components/widgets/widget-registry"
 
 // Replace the default IntSlider with your custom version
 registerWidget("IntSliderModel", MyCustomSlider)

--- a/content/docs/widgets/widget-store.mdx
+++ b/content/docs/widgets/widget-store.mdx
@@ -45,7 +45,7 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 Wrap your app with `WidgetStoreProvider`:
 
 ```tsx
-import { WidgetStoreProvider } from "@/registry/widgets/widget-store-context"
+import { WidgetStoreProvider } from "@/components/widgets/widget-store-context"
 
 function App() {
   const sendMessage = (msg) => {
@@ -66,7 +66,7 @@ function App() {
 Route incoming comm messages to the store:
 
 ```tsx
-import { useWidgetStoreRequired } from "@/lib/widget-store-context"
+import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context"
 
 function KernelMessageHandler({ kernel }) {
   const { handleMessage } = useWidgetStoreRequired()
@@ -91,7 +91,7 @@ import {
   useWidgetModels,
   useWidgetModel,
   useWidgetModelValue,
-} from "@/lib/widget-store-context"
+} from "@/components/widgets/widget-store-context"
 
 // Subscribe to ALL models (re-renders on any change)
 function ModelList() {

--- a/content/docs/widgets/widget-view.mdx
+++ b/content/docs/widgets/widget-view.mdx
@@ -47,9 +47,9 @@ Universal widget view component that routes widget models to the appropriate ren
 ### Basic Usage
 
 ```tsx
-import { WidgetView } from "@/registry/widgets/widget-view"
+import { WidgetView } from "@/components/widgets/widget-view"
 // Import to register built-in widgets
-import "@/registry/widgets/controls"
+import "@/components/widgets/controls"
 
 function NotebookOutput({ modelId }: { modelId: string }) {
   return <WidgetView modelId={modelId} />
@@ -59,9 +59,9 @@ function NotebookOutput({ modelId }: { modelId: string }) {
 ### With Provider
 
 ```tsx
-import { WidgetStoreProvider } from "@/registry/widgets/widget-store-context"
-import { WidgetView } from "@/registry/widgets/widget-view"
-import "@/registry/widgets/controls"
+import { WidgetStoreProvider } from "@/components/widgets/widget-store-context"
+import { WidgetView } from "@/components/widgets/widget-view"
+import "@/components/widgets/controls"
 
 function App() {
   return (
@@ -95,7 +95,7 @@ Model exists?
 
 ## Built-in Widgets
 
-24 ipywidgets are supported out of the box when you import `@/registry/widgets/controls`:
+24 ipywidgets are supported out of the box when you import `@/components/widgets/controls`:
 
 - **Sliders:** IntSlider, FloatSlider, IntRangeSlider, FloatRangeSlider
 - **Progress:** IntProgress, FloatProgress
@@ -114,7 +114,7 @@ Model exists?
 You can register your own widget components:
 
 ```tsx
-import { registerWidget } from "@/registry/widgets/widget-registry"
+import { registerWidget } from "@/components/widgets/widget-registry"
 
 // Create your component
 function MyCustomWidget({ modelId, className }: WidgetComponentProps) {


### PR DESCRIPTION
## Summary
Updated all code examples in documentation to use correct import paths matching registry.json target directories. Consumer code now shows imports from @/components/ instead of @/registry/ and @/lib/ paths.

## Changes
- Widget docs: @/lib/widget-* → @/components/widgets/*
- Widget controls: @/registry/widgets/* → @/components/widgets/*
- Output docs: @/registry/outputs/* → @/components/outputs/*
- Cell docs: @/registry/cell/* → @/components/cell/*
- Editor docs: @/registry/editor → @/components/editor

Live MDX imports at the top of files remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)