### PR TITLE
Add Audio and Video widgets

### DIFF
--- a/registry/widgets/controls/audio-widget.tsx
+++ b/registry/widgets/controls/audio-widget.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * Audio widget - plays audio from the kernel.
+ *
+ * Maps to ipywidgets AudioModel.
+ */
+
+import { useMemo } from "react";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+
+export function AudioWidget({ modelId, className }: WidgetComponentProps) {
+  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const format = useWidgetModelValue<string>(modelId, "format") ?? "mp3";
+  const autoplay = useWidgetModelValue<boolean>(modelId, "autoplay") ?? true;
+  const loop = useWidgetModelValue<boolean>(modelId, "loop") ?? true;
+  const controls = useWidgetModelValue<boolean>(modelId, "controls") ?? true;
+  const description = useWidgetModelValue<string>(modelId, "description");
+
+  const src = useMemo(() => {
+    if (!value) return undefined;
+    if (
+      value.startsWith("data:") ||
+      value.startsWith("http://") ||
+      value.startsWith("https://") ||
+      value.startsWith("/")
+    ) {
+      return value;
+    }
+    return `data:audio/${format};base64,${value}`;
+  }, [value, format]);
+
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("inline-flex items-start gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="Audio"
+    >
+      {description && (
+        <Label className="shrink-0 pt-1 text-sm">{description}</Label>
+      )}
+      {/* biome-ignore lint/a11y/useMediaCaption: ipywidgets audio does not provide captions */}
+      <audio src={src} autoPlay={autoplay} loop={loop} controls={controls} />
+    </div>
+  );
+}
+
+export default AudioWidget;

--- a/registry/widgets/controls/index.ts
+++ b/registry/widgets/controls/index.ts
@@ -7,6 +7,7 @@
 
 import { registerWidget } from "../widget-registry";
 import { AccordionWidget } from "./accordion-widget";
+import { AudioWidget } from "./audio-widget";
 import { BoundedFloatTextWidget } from "./bounded-float-text-widget";
 import { BoundedIntTextWidget } from "./bounded-int-text-widget";
 import { BoxWidget } from "./box-widget";
@@ -55,6 +56,7 @@ import { ToggleButtonsWidget } from "./toggle-buttons-widget";
 import { ValidWidget } from "./valid-widget";
 // Import layout widget components
 import { VBoxWidget } from "./vbox-widget";
+import { VideoWidget } from "./video-widget";
 
 // Register all widgets with their model names
 registerWidget("IntSliderModel", IntSlider);
@@ -75,6 +77,8 @@ registerWidget("HTMLModel", HTMLWidget);
 registerWidget("HTMLMathModel", HTMLMathWidget);
 registerWidget("LabelModel", LabelWidget);
 registerWidget("ImageModel", ImageWidget);
+registerWidget("AudioModel", AudioWidget);
+registerWidget("VideoModel", VideoWidget);
 registerWidget("ColorPickerModel", ColorPicker);
 registerWidget("DatePickerModel", DatePickerWidget);
 registerWidget("TimePickerModel", TimePickerWidget);
@@ -112,6 +116,7 @@ registerWidget("ControllerButtonModel", ControllerButtonWidget);
 registerWidget("ControllerAxisModel", ControllerAxisWidget);
 
 export { AccordionWidget } from "./accordion-widget";
+export { AudioWidget } from "./audio-widget";
 export { BoundedFloatTextWidget } from "./bounded-float-text-widget";
 export { BoundedIntTextWidget } from "./bounded-int-text-widget";
 export { BoxWidget } from "./box-widget";
@@ -160,3 +165,4 @@ export { ToggleButtonsWidget } from "./toggle-buttons-widget";
 export { ValidWidget } from "./valid-widget";
 // Re-export layout widgets
 export { VBoxWidget } from "./vbox-widget";
+export { VideoWidget } from "./video-widget";

--- a/registry/widgets/controls/video-widget.tsx
+++ b/registry/widgets/controls/video-widget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * Video widget - plays video from the kernel.
+ *
+ * Maps to ipywidgets VideoModel.
+ */
+
+import { useMemo } from "react";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+
+export function VideoWidget({ modelId, className }: WidgetComponentProps) {
+  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const format = useWidgetModelValue<string>(modelId, "format") ?? "mp4";
+  const width = useWidgetModelValue<string>(modelId, "width") ?? "";
+  const height = useWidgetModelValue<string>(modelId, "height") ?? "";
+  const autoplay = useWidgetModelValue<boolean>(modelId, "autoplay") ?? true;
+  const loop = useWidgetModelValue<boolean>(modelId, "loop") ?? true;
+  const controls = useWidgetModelValue<boolean>(modelId, "controls") ?? true;
+  const description = useWidgetModelValue<string>(modelId, "description");
+
+  const src = useMemo(() => {
+    if (!value) return undefined;
+    if (
+      value.startsWith("data:") ||
+      value.startsWith("http://") ||
+      value.startsWith("https://") ||
+      value.startsWith("/")
+    ) {
+      return value;
+    }
+    return `data:video/${format};base64,${value}`;
+  }, [value, format]);
+
+  if (!value) {
+    return null;
+  }
+
+  const style: React.CSSProperties = {};
+  if (width) style.width = width;
+  if (height) style.height = height;
+
+  return (
+    <div
+      className={cn("inline-flex items-start gap-3", className)}
+      data-widget-id={modelId}
+      data-widget-type="Video"
+    >
+      {description && (
+        <Label className="shrink-0 pt-1 text-sm">{description}</Label>
+      )}
+      {/* biome-ignore lint/a11y/useMediaCaption: ipywidgets video does not provide captions */}
+      <video
+        src={src}
+        autoPlay={autoplay}
+        loop={loop}
+        controls={controls}
+        style={style}
+        className="max-w-full"
+      />
+    </div>
+  );
+}
+
+export default VideoWidget;


### PR DESCRIPTION
## Summary
Implement AudioModel and VideoModel to support media playback in Jupyter notebooks. Both widgets wrap native HTML audio/video elements, support autoplay/loop/controls properties, and handle base64 encoded media data from the kernel.

## Changes
- Add `audio-widget.tsx` - renders HTML audio with format, autoplay, loop, and controls properties
- Add `video-widget.tsx` - renders HTML video with additional width/height support
- Register both models in the widget registry

## Testing
Audio and Video widgets now render properly when sent from the kernel with media data.