### PR TITLE
Add missing widget-controls registry files

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -660,6 +660,21 @@
           "path": "registry/widgets/controls/output-widget.tsx",
           "type": "registry:component",
           "target": "components/widgets/controls/output-widget.tsx"
+        },
+        {
+          "path": "registry/widgets/controls/button-style-utils.ts",
+          "type": "registry:lib",
+          "target": "components/widgets/controls/button-style-utils.ts"
+        },
+        {
+          "path": "registry/widgets/controls/audio-widget.tsx",
+          "type": "registry:component",
+          "target": "components/widgets/controls/audio-widget.tsx"
+        },
+        {
+          "path": "registry/widgets/controls/video-widget.tsx",
+          "type": "registry:component",
+          "target": "components/widgets/controls/video-widget.tsx"
         }
       ]
     },


### PR DESCRIPTION
Add button-style-utils.ts, audio-widget.tsx, and video-widget.tsx to the widget-controls registry. These files were imported by index.ts but missing from the registry file list, causing TypeScript errors on install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)