### PR TITLE
Fix TimePicker missing milliseconds field in time value

### DIFF
--- a/registry/widgets/controls/time-picker-widget.tsx
+++ b/registry/widgets/controls/time-picker-widget.tsx
@@ -53,7 +53,9 @@ export function TimePickerWidget({ modelId, className }: WidgetComponentProps) {
       const newValue = e.target.value;
       if (newValue) {
         const [hours, minutes] = newValue.split(":").map(Number);
-        sendUpdate(modelId, { value: { hours, minutes, seconds: 0, milliseconds: 0 } });
+        sendUpdate(modelId, {
+          value: { hours, minutes, seconds: 0, milliseconds: 0 },
+        });
       } else {
         sendUpdate(modelId, { value: null });
       }


### PR DESCRIPTION
TimePicker's handleChange was sending `{hours, minutes, seconds: 0}` to ipywidgets, but the ipywidgets `time_from_json` function expects a `milliseconds` key. This adds `milliseconds: 0` to match the expected format and resolve the KeyError.

Closes #119