### PR TITLE
Fix Audio/Video/Image widgets crashing with binary data

### DIFF
--- a/registry/widgets/buffer-utils.ts
+++ b/registry/widgets/buffer-utils.ts
@@ -134,6 +134,54 @@ export function extractBuffers(
 }
 
 /**
+ * Convert an ArrayBuffer or Uint8Array to a base64 string.
+ */
+export function arrayBufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Build a media src URL from a widget value that may be a string or binary data.
+ *
+ * Handles all value types sent by the Jupyter widget protocol:
+ * - Binary data (ArrayBuffer/Uint8Array) from from_url() or from_file()
+ * - Data URLs, HTTP URLs, or absolute paths (passed through)
+ * - Plain base64 strings (wrapped in a data URL)
+ * - Falsy values (returns undefined)
+ */
+export function buildMediaSrc(
+  value: string | ArrayBuffer | Uint8Array | null | undefined,
+  mediaType: string,
+  format: string,
+): string | undefined {
+  if (!value) return undefined;
+
+  if (value instanceof ArrayBuffer || value instanceof Uint8Array) {
+    const base64 = arrayBufferToBase64(value);
+    return `data:${mediaType}/${format};base64,${base64}`;
+  }
+
+  if (typeof value === "string") {
+    if (
+      value.startsWith("data:") ||
+      value.startsWith("http://") ||
+      value.startsWith("https://") ||
+      value.startsWith("/")
+    ) {
+      return value;
+    }
+    return `data:${mediaType}/${format};base64,${value}`;
+  }
+
+  return undefined;
+}
+
+/**
  * Find all ArrayBuffer values in an object and return their paths.
  *
  * Useful for automatically detecting buffer paths when sending data.

--- a/registry/widgets/controls/audio-widget.tsx
+++ b/registry/widgets/controls/audio-widget.tsx
@@ -9,29 +9,22 @@
 import { useMemo } from "react";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { buildMediaSrc } from "../buffer-utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 
 export function AudioWidget({ modelId, className }: WidgetComponentProps) {
-  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const value = useWidgetModelValue<string | ArrayBuffer>(modelId, "value");
   const format = useWidgetModelValue<string>(modelId, "format") ?? "mp3";
   const autoplay = useWidgetModelValue<boolean>(modelId, "autoplay") ?? true;
   const loop = useWidgetModelValue<boolean>(modelId, "loop") ?? true;
   const controls = useWidgetModelValue<boolean>(modelId, "controls") ?? true;
   const description = useWidgetModelValue<string>(modelId, "description");
 
-  const src = useMemo(() => {
-    if (!value) return undefined;
-    if (
-      value.startsWith("data:") ||
-      value.startsWith("http://") ||
-      value.startsWith("https://") ||
-      value.startsWith("/")
-    ) {
-      return value;
-    }
-    return `data:audio/${format};base64,${value}`;
-  }, [value, format]);
+  const src = useMemo(
+    () => buildMediaSrc(value, "audio", format),
+    [value, format],
+  );
 
   if (!value) {
     return null;

--- a/registry/widgets/controls/image-widget.tsx
+++ b/registry/widgets/controls/image-widget.tsx
@@ -8,29 +8,22 @@
 
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { buildMediaSrc } from "../buffer-utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 
 export function ImageWidget({ modelId, className }: WidgetComponentProps) {
-  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const value = useWidgetModelValue<string | ArrayBuffer>(modelId, "value");
   const format = useWidgetModelValue<string>(modelId, "format") ?? "png";
   const width = useWidgetModelValue<string>(modelId, "width") ?? "";
   const height = useWidgetModelValue<string>(modelId, "height") ?? "";
   const description = useWidgetModelValue<string>(modelId, "description");
 
-  if (!value) {
+  const src = buildMediaSrc(value, "image", format);
+
+  if (!src) {
     return null;
   }
-
-  // Construct data URL from base64 value
-  // If already a data URL or regular URL, use as-is
-  const src =
-    value.startsWith("data:") ||
-    value.startsWith("http://") ||
-    value.startsWith("https://") ||
-    value.startsWith("/")
-      ? value
-      : `data:image/${format};base64,${value}`;
 
   // Build style object for width/height
   const style: React.CSSProperties = {};

--- a/registry/widgets/controls/video-widget.tsx
+++ b/registry/widgets/controls/video-widget.tsx
@@ -9,11 +9,12 @@
 import { useMemo } from "react";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { buildMediaSrc } from "../buffer-utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 
 export function VideoWidget({ modelId, className }: WidgetComponentProps) {
-  const value = useWidgetModelValue<string>(modelId, "value") ?? "";
+  const value = useWidgetModelValue<string | ArrayBuffer>(modelId, "value");
   const format = useWidgetModelValue<string>(modelId, "format") ?? "mp4";
   const width = useWidgetModelValue<string>(modelId, "width") ?? "";
   const height = useWidgetModelValue<string>(modelId, "height") ?? "";
@@ -22,18 +23,10 @@ export function VideoWidget({ modelId, className }: WidgetComponentProps) {
   const controls = useWidgetModelValue<boolean>(modelId, "controls") ?? true;
   const description = useWidgetModelValue<string>(modelId, "description");
 
-  const src = useMemo(() => {
-    if (!value) return undefined;
-    if (
-      value.startsWith("data:") ||
-      value.startsWith("http://") ||
-      value.startsWith("https://") ||
-      value.startsWith("/")
-    ) {
-      return value;
-    }
-    return `data:video/${format};base64,${value}`;
-  }, [value, format]);
+  const src = useMemo(
+    () => buildMediaSrc(value, "video", format),
+    [value, format],
+  );
 
   if (!value) {
     return null;


### PR DESCRIPTION
## Summary
- Handle ArrayBuffer and Uint8Array values from Jupyter widget protocol
- Add `buildMediaSrc()` helper for consistent media URL construction
- Fix crash when using `from_url()` or `from_file()` on audio/video/image widgets

## Related
Fixes #120

🤖 Generated with Claude Code