### PR TITLE
Fix ipywidgets date field: use `date` not `day`

### DIFF
--- a/registry/widgets/controls/date-picker-widget.tsx
+++ b/registry/widgets/controls/date-picker-widget.tsx
@@ -16,15 +16,15 @@ import {
   useWidgetStoreRequired,
 } from "../widget-store-context";
 
-type IpyDate = { year: number; month: number; day: number } | null;
+type IpyDate = { year: number; month: number; date: number } | null;
 
 // Convert ipywidgets date object to YYYY-MM-DD format for input
 function toDateString(value: IpyDate): string {
   if (!value) return "";
   const year = String(value.year).padStart(4, "0");
   const month = String(value.month + 1).padStart(2, "0");
-  const day = String(value.day).padStart(2, "0");
-  return `${year}-${month}-${day}`;
+  const date = String(value.date).padStart(2, "0");
+  return `${year}-${month}-${date}`;
 }
 
 export function DatePickerWidget({ modelId, className }: WidgetComponentProps) {
@@ -42,7 +42,7 @@ export function DatePickerWidget({ modelId, className }: WidgetComponentProps) {
       const newValue = e.target.value;
       if (newValue) {
         const [year, month, day] = newValue.split("-").map(Number);
-        sendUpdate(modelId, { value: { year, month: month - 1, day } });
+        sendUpdate(modelId, { value: { year, month: month - 1, date: day } });
       } else {
         sendUpdate(modelId, { value: null });
       }

--- a/registry/widgets/controls/datetime-widget.tsx
+++ b/registry/widgets/controls/datetime-widget.tsx
@@ -20,7 +20,7 @@ type DatetimeValue =
   | {
       year: number;
       month: number;
-      day: number;
+      date: number;
       hour: number;
       minute: number;
       second: number;
@@ -45,10 +45,10 @@ function toDatetimeLocalString(value: DatetimeValue): string {
   // ipywidgets sends month as 0-indexed
   const year = String(value.year).padStart(4, "0");
   const month = String(value.month + 1).padStart(2, "0");
-  const day = String(value.day).padStart(2, "0");
+  const date = String(value.date).padStart(2, "0");
   const hour = String(value.hour).padStart(2, "0");
   const minute = String(value.minute).padStart(2, "0");
-  return `${year}-${month}-${day}T${hour}:${minute}`;
+  return `${year}-${month}-${date}T${hour}:${minute}`;
 }
 
 export function DatetimeWidget({ modelId, className }: WidgetComponentProps) {
@@ -65,15 +65,15 @@ export function DatetimeWidget({ modelId, className }: WidgetComponentProps) {
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       if (newValue) {
-        const date = new Date(newValue);
+        const d = new Date(newValue);
         sendUpdate(modelId, {
           value: {
-            year: date.getFullYear(),
-            month: date.getMonth(),
-            day: date.getDate(),
-            hour: date.getHours(),
-            minute: date.getMinutes(),
-            second: date.getSeconds(),
+            year: d.getFullYear(),
+            month: d.getMonth(),
+            date: d.getDate(),
+            hour: d.getHours(),
+            minute: d.getMinutes(),
+            second: d.getSeconds(),
             microsecond: 0,
           },
         });


### PR DESCRIPTION
## Summary
- ipywidgets serializes day-of-month as `date`, not `day`. Updated `DatePickerWidget` and `DatetimeWidget` to match.
- The Python deserializer (`date_from_json`) reads `js['date']`, so sending `day` caused a `KeyError`.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)