### PR TITLE
Fix registry: make canvas-manager-subscriptions self-contained

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -361,6 +361,11 @@
           "path": "registry/widgets/link-subscriptions.ts",
           "type": "registry:lib",
           "target": "components/widgets/link-subscriptions.ts"
+        },
+        {
+          "path": "registry/widgets/canvas-manager-subscriptions.ts",
+          "type": "registry:lib",
+          "target": "components/widgets/canvas-manager-subscriptions.ts"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- `canvas-manager-subscriptions.ts` imported from `./ipycanvas/ipycanvas-commands`, which doesn't exist when only `@nteract/widget-store` is installed (without `@nteract/ipycanvas`)
- Inlined `getTypedArray` (~15 lines) and replaced `COMMANDS[idx] === "switchCanvas"` with `SWITCH_CANVAS_CMD = 60` constant
- Added `canvas-manager-subscriptions.ts` to the `widget-store` files array in `registry.json`

## Test plan

- [x] `npx shadcn@latest add @nteract/widget-store` installs `canvas-manager-subscriptions.ts`
- [x] `pnpm run types:check` passes
- [x] ipycanvas multi-canvas still works (routing logic unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)