### PR TITLE
fix(anywidget): prevent remounting on state updates

### DIFF
--- a/registry/widgets/anywidget-view.tsx
+++ b/registry/widgets/anywidget-view.tsx
@@ -512,8 +512,8 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
     // - stableModelId: different widget instance
     // - esm: different widget code
     // - css: different widget styles
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stableModelId, esm, css]);
+    // getCurrentState and modelId are stable unless modelId changes (safe to include)
+  }, [stableModelId, esm, css, getCurrentState, modelId]);
 
   // Model not ready yet
   const modelExists = model !== undefined;


### PR DESCRIPTION
The useEffect dependency array included `model`, which gets a new object reference on every state update from useSyncExternalStore. This caused widgets like Plotly's FigureWidget to continuously unmount/remount when sending frequent state updates (pan, zoom, hover).

Use refs for store/sendMessage and extract stableModelId to only remount when the widget identity, ESM code, or CSS actually changes.