### PR TITLE
fix: brighten dark mode yellow background in ANSI output

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -131,7 +131,7 @@
     --ansi-black-bg: #484f58;
     --ansi-red-bg: #b31d28;
     --ansi-green-bg: #176f2c;
-    --ansi-yellow-bg: #735c0f;
+    --ansi-yellow-bg: #b5a000;
     --ansi-blue-bg: #1158c7;
     --ansi-magenta-bg: #5a32a3;
     --ansi-cyan-bg: #0e7481;


### PR DESCRIPTION
Changed --ansi-yellow-bg from #735c0f (olive/brown) to #b5a000 (golden yellow) for better readability in dark mode. Warning labels and highlighted text now render as clearly distinguishable yellow rather than muddy olive/brown.