### PR TITLE
docs: CSS variables guide + fix markdown-output missing import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,10 +120,26 @@ export function Example() {
 
 - [ ] Component placed in correct `registry/` subfolder
 - [ ] Entry added to `registry.json` with correct path
+- [ ] CSS variables (if any) match between `app/global.css` and `registry.json`
 - [ ] Imports use `@/components/ui/` for UI dependencies
 - [ ] Build passes: `pnpm run types:check`
 - [ ] MDX documentation created with interactive examples
 - [ ] Navigation updated in appropriate `meta.json`
+
+## CSS Variables
+
+Components using CSS variables must define them in **two places**:
+
+1. **`app/global.css`** — For the docs site (`:root` for light, `.dark` for dark)
+2. **`registry.json`** — Under `cssVars.light` and `cssVars.dark` for the component
+
+The shadcn CLI reads `cssVars` from registry.json and injects them into consumer CSS. If values don't match global.css, consumers get different colors than the docs site.
+
+**When changing CSS variables:**
+- Update both files with identical values
+- Test in both light and dark modes
+
+See `contributing/css-variables.md` for full details and examples.
 
 ## Utilities
 

--- a/contributing/css-variables.md
+++ b/contributing/css-variables.md
@@ -1,0 +1,68 @@
+# CSS Variables
+
+Components that use CSS variables must define them in **two places** to work correctly for both the docs site and consumers installing via the shadcn CLI.
+
+## Dual-Location Pattern
+
+### 1. `app/global.css`
+
+Define variables in both `:root` (light mode) and `.dark` (dark mode) selectors:
+
+```css
+:root {
+    --ansi-yellow-bg: #adad27;
+}
+
+.dark {
+    --ansi-yellow-bg: #b5a000;
+}
+```
+
+### 2. `registry.json`
+
+Add the same values to the component's `cssVars` object:
+
+```json
+{
+  "name": "ansi-output",
+  "cssVars": {
+    "light": {
+      "ansi-yellow-bg": "#adad27"
+    },
+    "dark": {
+      "ansi-yellow-bg": "#b5a000"
+    }
+  }
+}
+```
+
+## Why Both?
+
+- **`global.css`** — Used by the docs site at runtime
+- **`registry.json`** — Read by the shadcn CLI when consumers run `npx shadcn add @nteract/component-name`. The CLI injects these values into the consumer's CSS.
+
+If these values don't match, consumers see different colors than the docs site shows.
+
+## Checklist
+
+When adding or changing CSS variables:
+
+- [ ] Update `app/global.css` (both `:root` and `.dark` if theme-aware)
+- [ ] Update `registry.json` `cssVars.light` and `cssVars.dark`
+- [ ] Verify values match exactly between the two files
+
+## Example: ANSI Colors
+
+The `ansi-output` component defines 24 CSS variables for terminal colors (8 standard + 8 bright foreground colors, plus 8 background colors). All must be kept in sync between `global.css` and `registry.json`.
+
+## When to Use CSS Variables vs Tailwind
+
+**Use CSS variables when:**
+- Colors need to adapt to light/dark mode
+- Values are generated at runtime (e.g., from library output like `anser`)
+- You need the same semantic color across multiple elements
+
+**Use Tailwind classes when:**
+- Standard theme colors suffice (`bg-gray-100 dark:bg-gray-800`)
+- No runtime generation needed
+- The component doesn't need to expose customizable colors to consumers

--- a/registry.json
+++ b/registry.json
@@ -157,6 +157,11 @@
           "path": "registry/outputs/markdown-output.tsx",
           "type": "registry:component",
           "target": "components/outputs/markdown-output.tsx"
+        },
+        {
+          "path": "registry/outputs/dark-mode.ts",
+          "type": "registry:lib",
+          "target": "components/outputs/dark-mode.ts"
         }
       ]
     },

--- a/registry/outputs/dark-mode.ts
+++ b/registry/outputs/dark-mode.ts
@@ -1,0 +1,85 @@
+/**
+ * Dark mode detection utilities for output components.
+ * Checks document state and system preference to determine current mode.
+ */
+
+/**
+ * Check if the current environment prefers dark mode via system preference
+ */
+export function prefersDarkMode(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+/**
+ * Check if the document has dark mode enabled
+ * Checks multiple common patterns:
+ * - class="dark" or class="... dark ..." on <html>
+ * - color-scheme: dark on <html>
+ * - data-theme="dark" attribute
+ * - data-mode="dark" attribute
+ */
+export function documentHasDarkMode(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const html = document.documentElement;
+
+  // Check for 'dark' in classList (Tailwind / fumadocs pattern)
+  if (html.classList.contains("dark")) {
+    return true;
+  }
+
+  // Check color-scheme style
+  const colorScheme =
+    html.style.colorScheme || getComputedStyle(html).colorScheme;
+  if (colorScheme === "dark") {
+    return true;
+  }
+
+  // Check data-theme attribute (another common pattern)
+  if (html.getAttribute("data-theme") === "dark") {
+    return true;
+  }
+
+  // Check data-mode attribute
+  if (html.getAttribute("data-mode") === "dark") {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Detect dark mode from either document state or system preference.
+ * Prioritizes document state (site-level toggle) over system preference.
+ */
+export function isDarkMode(): boolean {
+  // Check document state first (site-level dark mode toggle)
+  if (documentHasDarkMode()) {
+    return true;
+  }
+
+  // Check if document explicitly has light mode set
+  if (typeof document !== "undefined") {
+    const html = document.documentElement;
+
+    // If 'light' class is present, respect it
+    if (html.classList.contains("light")) {
+      return false;
+    }
+
+    // If color-scheme is explicitly light, respect it
+    const colorScheme =
+      html.style.colorScheme || getComputedStyle(html).colorScheme;
+    if (colorScheme === "light") {
+      return false;
+    }
+  }
+
+  // Fall back to system preference
+  return prefersDarkMode();
+}

--- a/registry/outputs/markdown-output.tsx
+++ b/registry/outputs/markdown-output.tsx
@@ -13,7 +13,7 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { cn } from "@/lib/utils";
-import { isDarkMode } from "@/registry/editor/themes";
+import { isDarkMode } from "./dark-mode";
 
 import "katex/dist/katex.min.css";
 


### PR DESCRIPTION
## Summary

- Add `contributing/css-variables.md` documenting the dual-location pattern (global.css + registry.json)
- Update `AGENTS.md` with CSS variables section and checklist item
- Fix markdown-output import error by bundling `dark-mode.ts` utility

The markdown-output component was importing `isDarkMode` from `@/registry/editor/themes`, which doesn't exist for consumers installing via the registry. Now it includes its own bundled dark-mode utility.

## Test plan

- [x] `pnpm run types:check` passes
- [ ] Verify markdown-output installs correctly for consumers