### PR TITLE
Minor cell component updates

### DIFF
--- a/registry/cell/CellHeader.tsx
+++ b/registry/cell/CellHeader.tsx
@@ -7,8 +7,8 @@ interface CellHeaderProps {
   onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
   onDragStart?: (e: React.DragEvent) => void;
   draggable?: boolean;
-  leftContent?: ReactNode;
-  rightContent?: ReactNode;
+  leftContent: ReactNode;
+  rightContent: ReactNode;
 }
 
 export const CellHeader: React.FC<CellHeaderProps> = ({

--- a/registry/cell/CompactExecutionButton.tsx
+++ b/registry/cell/CompactExecutionButton.tsx
@@ -38,6 +38,7 @@ export function CompactExecutionButton({
   return (
     <button
       type="button"
+      data-testid="execute-button"
       onClick={handleClick}
       className={cn(
         "group/exec inline-flex items-center font-mono text-sm tabular-nums",
@@ -48,7 +49,7 @@ export function CompactExecutionButton({
       title={isExecuting ? "Stop execution" : "Run cell"}
     >
       <span className="opacity-60">[</span>
-      <span className="relative inline-flex w-4 items-center justify-center">
+      <span className="relative inline-flex min-w-4 items-center justify-center">
         {isExecuting ? (
           // Running state: show stop with pulse
           <span className="text-destructive animate-pulse">■</span>


### PR DESCRIPTION
## Summary

Small improvements to CellHeader and CompactExecutionButton synced from bandung-v2.

## Changes

- **CellHeader**: Make `leftContent` and `rightContent` props required (removes `?`)
- **CompactExecutionButton**: Add `data-testid="execute-button"` for testing
- **CompactExecutionButton**: Change `w-4` to `min-w-4` for better width handling with larger execution counts