### PR TITLE
Add widget layout utilities

### DIFF
--- a/registry/widgets/layout-utils.ts
+++ b/registry/widgets/layout-utils.ts
@@ -1,0 +1,182 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Utilities for converting ipywidgets Layout model properties to CSS.
+ *
+ * ipywidgets uses snake_case for CSS properties (e.g., grid_template_columns),
+ * which need to be converted to camelCase for React's style prop.
+ */
+
+/**
+ * Map of ipywidgets Layout model property names to React CSS property names.
+ * Only includes properties that need explicit mapping (non-trivial conversions).
+ */
+const LAYOUT_CSS_MAP: Record<string, string> = {
+  // Grid container properties
+  grid_template_columns: "gridTemplateColumns",
+  grid_template_rows: "gridTemplateRows",
+  grid_template_areas: "gridTemplateAreas",
+  grid_auto_columns: "gridAutoColumns",
+  grid_auto_rows: "gridAutoRows",
+  grid_auto_flow: "gridAutoFlow",
+  grid_gap: "gridGap",
+  // Grid child placement properties
+  grid_row: "gridRow",
+  grid_column: "gridColumn",
+  grid_area: "gridArea",
+  // Size properties
+  min_width: "minWidth",
+  max_width: "maxWidth",
+  min_height: "minHeight",
+  max_height: "maxHeight",
+  // Flexbox properties
+  flex_flow: "flexFlow",
+  align_items: "alignItems",
+  align_self: "alignSelf",
+  align_content: "alignContent",
+  justify_content: "justifyContent",
+  justify_items: "justifyItems",
+  // Text properties
+  object_fit: "objectFit",
+  object_position: "objectPosition",
+  // Overflow
+  overflow_x: "overflowX",
+  overflow_y: "overflowY",
+};
+
+/**
+ * Grid container properties that apply to the parent grid element.
+ */
+const CONTAINER_GRID_PROPERTIES = new Set([
+  "grid_template_columns",
+  "grid_template_rows",
+  "grid_template_areas",
+  "grid_auto_columns",
+  "grid_auto_rows",
+  "grid_auto_flow",
+  "grid_gap",
+]);
+
+/**
+ * Child placement properties that apply to grid children.
+ */
+const CHILD_GRID_PROPERTIES = new Set(["grid_row", "grid_column", "grid_area"]);
+
+/**
+ * General layout properties that can apply to any element.
+ */
+const GENERAL_PROPERTIES = new Set([
+  "width",
+  "height",
+  "min_width",
+  "max_width",
+  "min_height",
+  "max_height",
+  "margin",
+  "padding",
+  "border",
+  "overflow",
+  "overflow_x",
+  "overflow_y",
+  "visibility",
+  "display",
+  "flex",
+  "flex_flow",
+  "align_items",
+  "align_self",
+  "align_content",
+  "justify_content",
+  "justify_items",
+  "order",
+  "object_fit",
+  "object_position",
+]);
+
+/**
+ * Convert a snake_case property name to camelCase.
+ */
+function snakeToCamelCase(str: string): string {
+  return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+/**
+ * Convert an ipywidgets Layout property name to a React CSS property name.
+ */
+function toReactCSSProperty(snakeCase: string): string {
+  return LAYOUT_CSS_MAP[snakeCase] ?? snakeToCamelCase(snakeCase);
+}
+
+/**
+ * Extract CSS properties from a Layout model state.
+ *
+ * @param state - The Layout model's state object
+ * @param propertyFilter - Optional set of property names to include
+ * @returns React CSSProperties object
+ */
+export function layoutStateToCSS(
+  state: Record<string, unknown>,
+  propertyFilter?: Set<string>,
+): CSSProperties {
+  const style: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(state)) {
+    // Skip internal ipywidgets properties
+    if (key.startsWith("_")) continue;
+    // Skip null, undefined, or empty string values
+    if (value === null || value === undefined || value === "") continue;
+    // Apply filter if provided
+    if (propertyFilter && !propertyFilter.has(key)) continue;
+    // Only include string values (CSS values)
+    if (typeof value !== "string") continue;
+
+    const cssProperty = toReactCSSProperty(key);
+    style[cssProperty] = value;
+  }
+
+  return style as CSSProperties;
+}
+
+/**
+ * Extract container grid CSS properties from a Layout model state.
+ * These properties should be applied to grid container elements.
+ */
+export function extractContainerGridStyles(
+  state: Record<string, unknown>,
+): CSSProperties {
+  return layoutStateToCSS(state, CONTAINER_GRID_PROPERTIES);
+}
+
+/**
+ * Extract child placement CSS properties from a Layout model state.
+ * These properties should be applied to grid children for positioning.
+ */
+export function extractChildGridStyles(
+  state: Record<string, unknown>,
+): CSSProperties {
+  return layoutStateToCSS(state, CHILD_GRID_PROPERTIES);
+}
+
+/**
+ * Extract general layout CSS properties from a Layout model state.
+ * These can be applied to any element (width, height, margin, etc.).
+ */
+export function extractGeneralStyles(
+  state: Record<string, unknown>,
+): CSSProperties {
+  return layoutStateToCSS(state, GENERAL_PROPERTIES);
+}
+
+/**
+ * Check if a Layout model state has any grid container properties.
+ */
+export function hasContainerGridStyles(
+  state: Record<string, unknown>,
+): boolean {
+  for (const key of CONTAINER_GRID_PROPERTIES) {
+    const value = state[key];
+    if (value !== null && value !== undefined && value !== "") {
+      return true;
+    }
+  }
+  return false;
+}

--- a/registry/widgets/use-layout-styles.ts
+++ b/registry/widgets/use-layout-styles.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useMemo } from "react";
+import {
+  extractChildGridStyles,
+  extractContainerGridStyles,
+  extractGeneralStyles,
+  hasContainerGridStyles,
+} from "./layout-utils";
+import type { WidgetModel } from "./widget-store";
+import { useResolvedModelValue } from "./widget-store-context";
+
+/**
+ * Hook to extract CSS styles from a widget's Layout model.
+ *
+ * ipywidgets widgets have a `layout` property that references a LayoutModel.
+ * This hook resolves that reference and extracts CSS properties for styling.
+ *
+ * @param modelId - The widget model ID
+ * @returns Object with containerStyle (for grid containers) and childStyle (for grid_area positioning)
+ */
+export function useLayoutStyles(modelId: string): {
+  /** CSS grid container styles (grid_template_columns, grid_template_rows, etc.) + general styles */
+  containerStyle: CSSProperties;
+  /** CSS child placement styles (grid_area, grid_row, grid_column) */
+  childStyle: CSSProperties;
+  /** Whether the layout has grid container properties */
+  hasGridLayout: boolean;
+} {
+  // Resolve the layout model reference (IPY_MODEL_xxx -> LayoutModel)
+  const layoutModel = useResolvedModelValue(modelId, "layout") as
+    | WidgetModel
+    | undefined;
+
+  return useMemo(() => {
+    if (!layoutModel?.state) {
+      return {
+        containerStyle: {},
+        childStyle: {},
+        hasGridLayout: false,
+      };
+    }
+
+    const state = layoutModel.state;
+
+    // Extract different style categories
+    const gridContainerStyles = extractContainerGridStyles(state);
+    const generalStyles = extractGeneralStyles(state);
+    const childStyles = extractChildGridStyles(state);
+
+    // Combine container grid styles with general styles for the container
+    const containerStyle: CSSProperties = {
+      ...generalStyles,
+      ...gridContainerStyles,
+    };
+
+    return {
+      containerStyle,
+      childStyle: childStyles,
+      hasGridLayout: hasContainerGridStyles(state),
+    };
+  }, [layoutModel]);
+}


### PR DESCRIPTION
## Summary

Adds utilities for converting ipywidgets Layout model properties to React CSS styles.

## New Files

- **layout-utils.ts**: Converts ipywidgets snake_case layout props to React camelCase CSS
  - `layoutStateToCSS()` - Main conversion function
  - `extractContainerGridStyles()` - Grid container props (grid_template_columns, etc.)
  - `extractChildGridStyles()` - Grid child placement (grid_area, grid_row, grid_column)
  - `extractGeneralStyles()` - Width, height, margin, padding, etc.
  - `hasContainerGridStyles()` - Check for grid layout

- **use-layout-styles.ts**: React hook to extract styles from widget Layout models
  - Returns `{ containerStyle, childStyle, hasGridLayout }`
  - Resolves Layout model reference and extracts CSS properties