### PR TITLE
Add isolated renderer system for secure output rendering

### DIFF
--- a/content/docs/cell/cell-container.mdx
+++ b/content/docs/cell/cell-container.mdx
@@ -44,7 +44,7 @@ CellContainer uses a **paper margins** design with symmetric gutters:
 
 ## Usage
 
-Use `CompactExecutionButton` for the classic Jupyter/Colab `[n]:` style:
+Use `CompactExecutionButton` for the classic Jupyter `[n]:` style:
 
 ```tsx
 import { CellContainer } from "@/components/cell/CellContainer";

--- a/registry.json
+++ b/registry.json
@@ -844,6 +844,40 @@
       ]
     },
     {
+      "name": "isolated-frame",
+      "type": "registry:component",
+      "title": "Isolated Frame",
+      "description": "Secure iframe component for rendering untrusted output content. Uses blob URLs with sandbox restrictions to isolate JavaScript execution. Includes message bridge for parent-child communication and widget comm protocol support.",
+      "registryDependencies": ["@nteract/widget-store"],
+      "files": [
+        {
+          "path": "registry/outputs/isolated/index.ts",
+          "type": "registry:lib",
+          "target": "components/outputs/isolated/index.ts"
+        },
+        {
+          "path": "registry/outputs/isolated/isolated-frame.tsx",
+          "type": "registry:component",
+          "target": "components/outputs/isolated/isolated-frame.tsx"
+        },
+        {
+          "path": "registry/outputs/isolated/frame-bridge.ts",
+          "type": "registry:lib",
+          "target": "components/outputs/isolated/frame-bridge.ts"
+        },
+        {
+          "path": "registry/outputs/isolated/frame-html.ts",
+          "type": "registry:lib",
+          "target": "components/outputs/isolated/frame-html.ts"
+        },
+        {
+          "path": "registry/outputs/isolated/comm-bridge-manager.ts",
+          "type": "registry:lib",
+          "target": "components/outputs/isolated/comm-bridge-manager.ts"
+        }
+      ]
+    },
+    {
       "name": "cell-type-selector",
       "type": "registry:component",
       "title": "CellTypeSelector",

--- a/registry/outputs/isolated/comm-bridge-manager.ts
+++ b/registry/outputs/isolated/comm-bridge-manager.ts
@@ -1,0 +1,460 @@
+/**
+ * Comm Bridge Manager - Parent Side
+ *
+ * This module manages the communication bridge between the parent window's
+ * widget system and an isolated iframe. It:
+ * - Buffers comm messages until iframe sends `widget_ready`
+ * - Syncs all existing widget models to iframe on ready
+ * - Forwards comm messages from kernel to iframe
+ * - Handles widget messages from iframe and updates parent store + kernel
+ *
+ * Security: The iframe cannot access Tauri APIs directly. All widget
+ * communication must go through this controlled postMessage bridge.
+ */
+
+import type { WidgetStore } from "@/registry/widgets/widget-store";
+import type {
+  CommCloseMessage,
+  CommMsgMessage,
+  CommOpenMessage,
+  CommSyncMessage,
+  IframeToParentMessage,
+} from "./frame-bridge";
+import type { IsolatedFrameHandle } from "./isolated-frame";
+
+// Type for sending messages to kernel
+type SendUpdate = (
+  commId: string,
+  state: Record<string, unknown>,
+  buffers?: ArrayBuffer[],
+) => void;
+
+type SendCustom = (
+  commId: string,
+  content: Record<string, unknown>,
+  buffers?: ArrayBuffer[],
+) => void;
+
+type CloseComm = (commId: string) => void;
+
+interface CommBridgeManagerOptions {
+  /** The isolated frame handle for sending messages */
+  frame: IsolatedFrameHandle;
+  /** The parent widget store */
+  store: WidgetStore;
+  /** Function to send state updates to kernel */
+  sendUpdate: SendUpdate;
+  /** Function to send custom messages to kernel */
+  sendCustom: SendCustom;
+  /** Function to close a comm with kernel */
+  closeComm: CloseComm;
+}
+
+/**
+ * Comm Bridge Manager for proxying widget communication to an isolated iframe.
+ *
+ * Usage:
+ * 1. Create manager when IsolatedFrame is mounted
+ * 2. Subscribe to widget store changes to forward to iframe
+ * 3. Handle iframe messages via onMessage callback
+ * 4. Dispose when iframe is unmounted
+ */
+export class CommBridgeManager {
+  private frame: IsolatedFrameHandle;
+  private store: WidgetStore;
+  private sendUpdateToKernel: SendUpdate;
+  private sendCustomToKernel: SendCustom;
+  private closeCommWithKernel: CloseComm;
+
+  private isWidgetReady = false;
+  private messageBuffer: Array<
+    CommOpenMessage | CommMsgMessage | CommCloseMessage
+  > = [];
+  private storeUnsubscribe: (() => void) | null = null;
+
+  // Track which models have been sent to avoid duplicate sends
+  private sentModels = new Set<string>();
+
+  // Track previous state for each model to detect kernel updates
+  private previousState = new Map<string, Record<string, unknown>>();
+
+  // Flag to prevent echoing iframe updates back to iframe
+  private isProcessingIframeUpdate = false;
+
+  // Track custom message subscriptions for each model
+  private customMessageUnsubscribers = new Map<string, () => void>();
+
+  constructor(options: CommBridgeManagerOptions) {
+    this.frame = options.frame;
+    this.store = options.store;
+    this.sendUpdateToKernel = options.sendUpdate;
+    this.sendCustomToKernel = options.sendCustom;
+    this.closeCommWithKernel = options.closeComm;
+
+    // Subscribe to store changes to forward to iframe
+    this.storeUnsubscribe = this.store.subscribe(() => {
+      if (!this.isWidgetReady) return;
+      // Skip if this change came from iframe (avoid echo)
+      if (this.isProcessingIframeUpdate) return;
+      this.syncModels();
+    });
+
+    // Signal to iframe that parent bridge is ready
+    // Iframe will respond with widget_ready to trigger comm_sync
+    this.frame.send({ type: "bridge_ready" });
+  }
+
+  /**
+   * Handle a message from the iframe.
+   * Call this from the IsolatedFrame's onMessage callback.
+   */
+  handleIframeMessage(message: IframeToParentMessage): void {
+    switch (message.type) {
+      case "widget_ready":
+        this.handleWidgetReady();
+        break;
+
+      case "widget_comm_msg":
+        this.handleWidgetCommMsg(message.payload);
+        break;
+
+      case "widget_comm_close":
+        this.handleWidgetCommClose(message.payload);
+        break;
+    }
+  }
+
+  /**
+   * Forward a comm_open to the iframe.
+   * Called when a widget model is created by the kernel.
+   */
+  sendCommOpen(
+    commId: string,
+    targetName: string,
+    state: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): void {
+    const msg: CommOpenMessage = {
+      type: "comm_open",
+      payload: {
+        commId,
+        targetName,
+        state,
+        buffers,
+      },
+    };
+
+    if (this.isWidgetReady) {
+      this.frame.send(msg);
+      this.sentModels.add(commId);
+    } else {
+      this.messageBuffer.push(msg);
+    }
+  }
+
+  /**
+   * Forward a comm_msg (state update or custom message) to the iframe.
+   * Called when the kernel sends a state update or custom message.
+   */
+  sendCommMsg(
+    commId: string,
+    method: "update" | "custom",
+    data: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): void {
+    const msg: CommMsgMessage = {
+      type: "comm_msg",
+      payload: {
+        commId,
+        method,
+        data,
+        buffers,
+      },
+    };
+
+    if (this.isWidgetReady) {
+      this.frame.send(msg);
+    } else {
+      this.messageBuffer.push(msg);
+    }
+  }
+
+  /**
+   * Forward a comm_close to the iframe.
+   * Called when the kernel closes a widget.
+   */
+  sendCommClose(commId: string): void {
+    const msg: CommCloseMessage = {
+      type: "comm_close",
+      payload: { commId },
+    };
+
+    if (this.isWidgetReady) {
+      this.frame.send(msg);
+      this.sentModels.delete(commId);
+    } else {
+      this.messageBuffer.push(msg);
+    }
+  }
+
+  /**
+   * Clean up subscriptions and state.
+   */
+  dispose(): void {
+    if (this.storeUnsubscribe) {
+      this.storeUnsubscribe();
+      this.storeUnsubscribe = null;
+    }
+    // Unsubscribe from all custom message subscriptions
+    for (const unsubscribe of this.customMessageUnsubscribers.values()) {
+      unsubscribe();
+    }
+    this.customMessageUnsubscribers.clear();
+    this.messageBuffer = [];
+    this.sentModels.clear();
+    this.previousState.clear();
+    this.isWidgetReady = false;
+  }
+
+  // --- Private Methods ---
+
+  private handleWidgetReady(): void {
+    this.isWidgetReady = true;
+
+    // Send comm_sync with all existing models
+    const models = this.store.getSnapshot();
+    const modelArray: CommSyncMessage["payload"]["models"] = [];
+
+    for (const [commId, model] of models) {
+      modelArray.push({
+        commId,
+        targetName: model.modelModule || "jupyter.widget",
+        state: model.state,
+        buffers: model.buffers,
+      });
+      this.sentModels.add(commId);
+      // Store initial state for change detection
+      this.previousState.set(commId, this.cloneStateSnapshot(model.state));
+      // Subscribe to custom messages for this model
+      this.subscribeToModelCustomMessages(commId);
+    }
+
+    if (modelArray.length > 0) {
+      const syncMsg: CommSyncMessage = {
+        type: "comm_sync",
+        payload: { models: modelArray },
+      };
+      try {
+        this.frame.send(syncMsg);
+      } catch (e) {
+        console.error("[CommBridge] Error sending comm_sync:", e);
+      }
+    }
+
+    // Flush buffered messages
+    for (const msg of this.messageBuffer) {
+      this.frame.send(msg);
+      if (msg.type === "comm_open") {
+        this.sentModels.add(msg.payload.commId);
+      } else if (msg.type === "comm_close") {
+        this.sentModels.delete(msg.payload.commId);
+      }
+    }
+    this.messageBuffer = [];
+  }
+
+  private handleWidgetCommMsg(payload: {
+    commId: string;
+    method: "update" | "custom";
+    data: Record<string, unknown>;
+    bufferPaths?: string[][];
+    buffers?: ArrayBuffer[];
+  }): void {
+    const { commId, method, data, buffers } = payload;
+
+    if (method === "update") {
+      // Set flag to prevent echoing this update back to iframe
+      this.isProcessingIframeUpdate = true;
+      try {
+        // Update parent store first (so UI stays in sync)
+        this.store.updateModel(commId, data, buffers);
+        // Update our tracked state
+        const current = this.previousState.get(commId) ?? {};
+        this.previousState.set(
+          commId,
+          this.cloneStateSnapshot({ ...current, ...data }),
+        );
+        // Then forward to kernel
+        this.sendUpdateToKernel(commId, data, buffers);
+      } finally {
+        this.isProcessingIframeUpdate = false;
+      }
+    } else if (method === "custom") {
+      // Custom messages go directly to kernel (no store update)
+      this.sendCustomToKernel(commId, data, buffers);
+    }
+  }
+
+  private handleWidgetCommClose(payload: { commId: string }): void {
+    const { commId } = payload;
+
+    // Update parent store
+    this.store.deleteModel(commId);
+    // Forward to kernel
+    this.closeCommWithKernel(commId);
+    // Clean up tracking
+    this.sentModels.delete(commId);
+  }
+
+  /**
+   * Sync models with iframe: new models, deleted models, and state changes.
+   * Called when store changes after widget_ready.
+   */
+  private syncModels(): void {
+    const models = this.store.getSnapshot();
+
+    for (const [commId, model] of models) {
+      if (!this.sentModels.has(commId)) {
+        // New model - send comm_open
+        this.sendCommOpen(
+          commId,
+          model.modelModule || "jupyter.widget",
+          model.state,
+          model.buffers,
+        );
+        // Store initial state for change detection
+        this.previousState.set(commId, this.cloneStateSnapshot(model.state));
+        // Subscribe to custom messages for this model
+        this.subscribeToModelCustomMessages(commId);
+      } else {
+        // Existing model - check for state changes
+        const previous = this.previousState.get(commId);
+        if (previous) {
+          const changedKeys = this.getChangedKeys(previous, model.state);
+          if (changedKeys.length > 0) {
+            // Build delta with only changed keys
+            const delta: Record<string, unknown> = {};
+            for (const key of changedKeys) {
+              delta[key] = model.state[key];
+            }
+            // Forward state update to iframe
+            this.sendCommMsg(commId, "update", delta, model.buffers);
+            // Update tracked state
+            this.previousState.set(
+              commId,
+              this.cloneStateSnapshot(model.state),
+            );
+          }
+        }
+      }
+    }
+
+    // Check for deleted models
+    for (const commId of this.sentModels) {
+      if (!models.has(commId)) {
+        this.sendCommClose(commId);
+        this.previousState.delete(commId);
+        // Unsubscribe from custom messages
+        this.unsubscribeFromModelCustomMessages(commId);
+      }
+    }
+  }
+
+  /**
+   * Subscribe to custom messages for a model and forward them to iframe.
+   * This is critical for anywidgets like quak that use custom messages for data.
+   */
+  private subscribeToModelCustomMessages(commId: string): void {
+    // Don't double-subscribe
+    if (this.customMessageUnsubscribers.has(commId)) return;
+
+    const unsubscribe = this.store.subscribeToCustomMessage(
+      commId,
+      (content, buffers) => {
+        // Convert DataView[] to ArrayBuffer[] for postMessage
+        const arrayBuffers = buffers?.map((dv) => dv.buffer as ArrayBuffer);
+        // Forward custom message to iframe
+        this.sendCommMsg(commId, "custom", content, arrayBuffers);
+      },
+    );
+
+    this.customMessageUnsubscribers.set(commId, unsubscribe);
+  }
+
+  /**
+   * Unsubscribe from custom messages for a model.
+   */
+  private unsubscribeFromModelCustomMessages(commId: string): void {
+    const unsubscribe = this.customMessageUnsubscribers.get(commId);
+    if (unsubscribe) {
+      unsubscribe();
+      this.customMessageUnsubscribers.delete(commId);
+    }
+  }
+
+  /**
+   * Get keys that have changed between two state objects.
+   * Uses shallow comparison for performance.
+   */
+  private getChangedKeys(
+    previous: Record<string, unknown>,
+    current: Record<string, unknown>,
+  ): string[] {
+    const changed: string[] = [];
+    const allKeys = new Set([
+      ...Object.keys(previous),
+      ...Object.keys(current),
+    ]);
+    for (const key of allKeys) {
+      if (this.valuesAreDifferent(previous[key], current[key])) {
+        changed.push(key);
+      }
+    }
+    return changed;
+  }
+
+  /**
+   * Create a deep snapshot of model state so future in-place mutations are detectable.
+   */
+  private cloneStateSnapshot(
+    state: Record<string, unknown>,
+  ): Record<string, unknown> {
+    try {
+      return structuredClone(state);
+    } catch {
+      return { ...state };
+    }
+  }
+
+  /**
+   * Compare two state values.
+   * For object/array values, use JSON content comparison so deep snapshots
+   * can detect in-place mutations from live state objects.
+   */
+  private valuesAreDifferent(previous: unknown, current: unknown): boolean {
+    if (
+      typeof previous !== "object" ||
+      previous === null ||
+      typeof current !== "object" ||
+      current === null
+    ) {
+      return previous !== current;
+    }
+
+    try {
+      return JSON.stringify(previous) !== JSON.stringify(current);
+    } catch {
+      // If value can't be serialized consistently, err on sending an update.
+      return true;
+    }
+  }
+}
+
+/**
+ * Create a comm bridge manager for an isolated frame.
+ */
+export function createCommBridgeManager(
+  options: CommBridgeManagerOptions,
+): CommBridgeManager {
+  return new CommBridgeManager(options);
+}

--- a/registry/outputs/isolated/frame-bridge.ts
+++ b/registry/outputs/isolated/frame-bridge.ts
@@ -1,0 +1,405 @@
+/**
+ * Message protocol types for parent ↔ iframe communication.
+ *
+ * This module defines the contract between the parent window and isolated output frames.
+ * All communication happens via postMessage with structured message types.
+ */
+
+// --- Message Types: Parent → Iframe ---
+
+/**
+ * Bootstrap the iframe with JavaScript code.
+ * Used to inject the ESM renderer bundle into the iframe.
+ */
+export interface EvalMessage {
+  type: "eval";
+  payload: {
+    /** JavaScript code to evaluate in the iframe context */
+    code: string;
+  };
+}
+
+/**
+ * Render output content in the iframe.
+ */
+export interface RenderMessage {
+  type: "render";
+  payload: RenderPayload;
+}
+
+export interface RenderPayload {
+  /** MIME type of the content (e.g., "text/html", "text/markdown") */
+  mimeType: string;
+  /** The content data (format depends on MIME type) */
+  data: unknown;
+  /** Optional metadata for the output */
+  metadata?: Record<string, unknown>;
+  /** Cell ID this output belongs to (for routing) */
+  cellId?: string;
+  /** Output index within the cell */
+  outputIndex?: number;
+  /** If true, append to existing outputs instead of replacing */
+  append?: boolean;
+  /** If true, replace all existing outputs with this single output */
+  replace?: boolean;
+}
+
+/**
+ * Update widget state in the iframe.
+ */
+export interface WidgetStateMessage {
+  type: "widget_state";
+  payload: {
+    /** Comm ID of the widget */
+    commId: string;
+    /** Updated state to merge */
+    state: Record<string, unknown>;
+    /** Optional buffers (base64 encoded) */
+    buffers?: string[];
+  };
+}
+
+/**
+ * Sync theme with the iframe.
+ */
+export interface ThemeMessage {
+  type: "theme";
+  payload: {
+    /** Whether dark mode is active */
+    isDark: boolean;
+    /** Optional CSS variables to inject */
+    cssVariables?: Record<string, string>;
+  };
+}
+
+/**
+ * Ping the iframe (for health checks and latency measurement).
+ */
+export interface PingMessage {
+  type: "ping";
+  payload?: {
+    sentAt: number;
+  };
+}
+
+/**
+ * Clear all rendered content in the iframe.
+ */
+export interface ClearMessage {
+  type: "clear";
+}
+
+// --- Widget Comm Protocol: Parent → Iframe ---
+
+/**
+ * Forward a comm_open message to the iframe.
+ * Sent when a widget model is created by the kernel.
+ */
+export interface CommOpenMessage {
+  type: "comm_open";
+  payload: {
+    /** Comm ID of the widget */
+    commId: string;
+    /** Target name (e.g., "jupyter.widget") */
+    targetName: string;
+    /** Initial widget state */
+    state: Record<string, unknown>;
+    /** Buffer paths for binary data reconstruction */
+    bufferPaths?: string[][];
+    /** Binary buffers (transferred via structured clone) */
+    buffers?: ArrayBuffer[];
+  };
+}
+
+/**
+ * Forward a comm_msg to the iframe.
+ * Sent for state updates and custom messages from kernel.
+ */
+export interface CommMsgMessage {
+  type: "comm_msg";
+  payload: {
+    /** Comm ID of the widget */
+    commId: string;
+    /** Message method: "update" or "custom" */
+    method: "update" | "custom";
+    /** State patch (for update) or custom content (for custom) */
+    data: Record<string, unknown>;
+    /** Buffer paths for binary data reconstruction */
+    bufferPaths?: string[][];
+    /** Binary buffers (transferred via structured clone) */
+    buffers?: ArrayBuffer[];
+  };
+}
+
+/**
+ * Forward a comm_close message to the iframe.
+ * Sent when a widget is destroyed by the kernel.
+ */
+export interface CommCloseMessage {
+  type: "comm_close";
+  payload: {
+    /** Comm ID of the widget to close */
+    commId: string;
+  };
+}
+
+/**
+ * Sync all existing widget models to the iframe.
+ * Sent on iframe ready to bootstrap existing widgets.
+ */
+export interface CommSyncMessage {
+  type: "comm_sync";
+  payload: {
+    /** Array of existing models to sync */
+    models: Array<{
+      commId: string;
+      targetName: string;
+      state: Record<string, unknown>;
+      buffers?: ArrayBuffer[];
+    }>;
+  };
+}
+
+/**
+ * Signal that the parent's comm bridge is ready.
+ * Iframe should respond with widget_ready to trigger comm_sync.
+ */
+export interface BridgeReadyMessage {
+  type: "bridge_ready";
+}
+
+/**
+ * All message types that can be sent from parent to iframe.
+ */
+export type ParentToIframeMessage =
+  | EvalMessage
+  | RenderMessage
+  | WidgetStateMessage
+  | ThemeMessage
+  | PingMessage
+  | ClearMessage
+  | CommOpenMessage
+  | CommMsgMessage
+  | CommCloseMessage
+  | CommSyncMessage
+  | BridgeReadyMessage;
+
+// --- Message Types: Iframe → Parent ---
+
+/**
+ * Iframe has finished loading and is ready to receive messages.
+ */
+export interface ReadyMessage {
+  type: "ready";
+}
+
+/**
+ * Response to a ping message.
+ */
+export interface PongMessage {
+  type: "pong";
+  payload: {
+    receivedAt: number;
+    /** Echo back the payload from the ping */
+    echo?: unknown;
+  };
+}
+
+/**
+ * Result of evaluating code in the iframe.
+ */
+export interface EvalResultMessage {
+  type: "eval_result";
+  payload: {
+    success: boolean;
+    result?: string;
+    error?: string;
+  };
+}
+
+/**
+ * Iframe content has finished rendering.
+ */
+export interface RenderCompleteMessage {
+  type: "render_complete";
+  payload?: {
+    /** Height of the rendered content */
+    height?: number;
+  };
+}
+
+/**
+ * Iframe content size has changed.
+ */
+export interface ResizeMessage {
+  type: "resize";
+  payload: {
+    /** New height of the content */
+    height: number;
+    /** New width of the content (optional) */
+    width?: number;
+  };
+}
+
+/**
+ * User clicked a link in the iframe.
+ */
+export interface LinkClickMessage {
+  type: "link_click";
+  payload: {
+    /** The URL that was clicked */
+    url: string;
+    /** Whether it was a ctrl/cmd click */
+    newTab: boolean;
+  };
+}
+
+/**
+ * User double-clicked in the iframe.
+ */
+export interface DoubleClickMessage {
+  type: "dblclick";
+}
+
+/**
+ * Widget state was updated in the iframe (needs to sync to kernel).
+ */
+export interface WidgetUpdateMessage {
+  type: "widget_update";
+  payload: {
+    /** Comm ID of the widget */
+    commId: string;
+    /** Updated state */
+    state: Record<string, unknown>;
+    /** Optional buffers (base64 encoded) */
+    buffers?: string[];
+  };
+}
+
+/**
+ * An error occurred in the iframe.
+ */
+export interface IframeErrorMessage {
+  type: "error";
+  payload: {
+    message: string;
+    stack?: string;
+  };
+}
+
+/**
+ * The React renderer bundle has been loaded and initialized.
+ * This is sent after the bundle is eval'd and React is mounted.
+ */
+export interface RendererReadyMessage {
+  type: "renderer_ready";
+}
+
+// --- Widget Comm Protocol: Iframe → Parent ---
+
+/**
+ * Iframe widget system is ready to receive comm messages.
+ * Parent should send comm_sync with existing models after this.
+ */
+export interface WidgetReadyMessage {
+  type: "widget_ready";
+}
+
+/**
+ * Widget initiated a state update or custom message.
+ * Parent should forward to kernel and update its store.
+ */
+export interface WidgetCommMsgMessage {
+  type: "widget_comm_msg";
+  payload: {
+    /** Comm ID of the widget */
+    commId: string;
+    /** Message method: "update" or "custom" */
+    method: "update" | "custom";
+    /** State patch or custom content */
+    data: Record<string, unknown>;
+    /** Buffer paths */
+    bufferPaths?: string[][];
+    /** Binary buffers */
+    buffers?: ArrayBuffer[];
+  };
+}
+
+/**
+ * Widget initiated comm close.
+ * Parent should forward to kernel and clean up.
+ */
+export interface WidgetCommCloseMessage {
+  type: "widget_comm_close";
+  payload: {
+    /** Comm ID of the widget to close */
+    commId: string;
+  };
+}
+
+/**
+ * All message types that can be sent from iframe to parent.
+ */
+export type IframeToParentMessage =
+  | ReadyMessage
+  | PongMessage
+  | EvalResultMessage
+  | RenderCompleteMessage
+  | ResizeMessage
+  | LinkClickMessage
+  | DoubleClickMessage
+  | WidgetUpdateMessage
+  | IframeErrorMessage
+  | RendererReadyMessage
+  | WidgetReadyMessage
+  | WidgetCommMsgMessage
+  | WidgetCommCloseMessage;
+
+// --- Utility Types ---
+
+/**
+ * All message types (for generic handling).
+ */
+export type IframeMessage = ParentToIframeMessage | IframeToParentMessage;
+
+/**
+ * Extract the message type string.
+ */
+export type MessageType = IframeMessage["type"];
+
+/**
+ * Type guard to check if a message is from the iframe.
+ */
+export function isIframeMessage(data: unknown): data is IframeToParentMessage {
+  if (typeof data !== "object" || data === null) return false;
+  const msg = data as { type?: unknown };
+  return (
+    typeof msg.type === "string" &&
+    [
+      "ready",
+      "pong",
+      "eval_result",
+      "render_complete",
+      "resize",
+      "link_click",
+      "dblclick",
+      "widget_update",
+      "error",
+      "renderer_ready",
+      "widget_ready",
+      "widget_comm_msg",
+      "widget_comm_close",
+    ].includes(msg.type)
+  );
+}
+
+/**
+ * Type guard for specific message types.
+ */
+export function isMessageType<T extends IframeMessage["type"]>(
+  data: unknown,
+  type: T,
+): data is Extract<IframeMessage, { type: T }> {
+  if (typeof data !== "object" || data === null) return false;
+  return (data as { type?: unknown }).type === type;
+}

--- a/registry/outputs/isolated/frame-html.ts
+++ b/registry/outputs/isolated/frame-html.ts
@@ -1,0 +1,468 @@
+/**
+ * HTML template generator for isolated output frames.
+ *
+ * Creates the minimal HTML document that runs inside the blob URL iframe.
+ * This document handles the message protocol and provides a render target
+ * for output content.
+ *
+ * Security: This code runs in an isolated origin (blob:) with sandbox
+ * restrictions, so it cannot access Tauri APIs or the parent DOM.
+ */
+
+export interface FrameHtmlOptions {
+  /**
+   * Whether to include dark mode styles by default.
+   */
+  darkMode?: boolean;
+  /**
+   * Additional CSS to inject into the frame.
+   */
+  additionalCss?: string;
+  /**
+   * Additional JavaScript to inject (runs after bootstrap).
+   */
+  additionalScript?: string;
+}
+
+/**
+ * Generate the HTML template for an isolated output frame.
+ *
+ * The generated HTML includes:
+ * - Basic styling for outputs (respects light/dark mode)
+ * - Message handler for parent communication
+ * - ResizeObserver for auto-sizing
+ * - Ready notification on load
+ *
+ * @param options - Configuration options for the frame
+ * @returns HTML string to be used with a blob URL
+ */
+export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
+  const {
+    darkMode = true,
+    additionalCss = "",
+    additionalScript = "",
+  } = options;
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline'; img-src * data: blob:; font-src * data:; connect-src *;">
+  <style>
+    :root {
+      --bg-primary: ${darkMode ? "#0a0a0a" : "#ffffff"};
+      --bg-secondary: ${darkMode ? "#1a1a1a" : "#f5f5f5"};
+      --text-primary: ${darkMode ? "#e0e0e0" : "#1a1a1a"};
+      --text-secondary: ${darkMode ? "#a0a0a0" : "#666666"};
+      --border-color: ${darkMode ? "#333333" : "#e0e0e0"};
+      --accent-color: #3b82f6;
+      --error-color: #ef4444;
+      --success-color: #22c55e;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      background: transparent;
+      color: var(--text-primary);
+    }
+
+    body {
+      padding: 8px;
+    }
+
+    /* Output container */
+    #root {
+      min-height: 1px;
+    }
+
+    /* Reset common elements - 0.875rem matches Tailwind's text-sm */
+    pre, code {
+      font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.875rem;
+    }
+
+    pre {
+      margin: 0;
+      padding: 8px;
+      background: var(--bg-secondary);
+      border-radius: 4px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    /* Table styling for pandas DataFrames - 0.875rem matches Tailwind's text-sm */
+    table {
+      border-collapse: collapse;
+      margin: 8px 0;
+      font-size: 0.875rem;
+    }
+
+    th, td {
+      border: 1px solid var(--border-color);
+      padding: 4px 8px;
+      text-align: left;
+    }
+
+    th {
+      background: var(--bg-secondary);
+      font-weight: 600;
+    }
+
+    /* Image outputs */
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    /* Links */
+    a {
+      color: var(--accent-color);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    /* Error styling */
+    .error {
+      color: var(--error-color);
+    }
+
+    .error pre {
+      background: ${darkMode ? "#1a1010" : "#fef2f2"};
+      color: var(--error-color);
+    }
+
+    ${additionalCss}
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script>
+    (function() {
+      'use strict';
+
+      // --- State ---
+      let isReady = false;
+      const root = document.getElementById('root');
+
+      // --- Message Handler ---
+      // Note: When the React renderer bundle is loaded, it sets window.__REACT_RENDERER_ACTIVE__
+      // and the inline handlers should defer to React for render/theme/clear messages.
+      window.addEventListener('message', function(event) {
+        // Only accept messages from our parent window
+        if (event.source !== window.parent) {
+          return;
+        }
+
+        const { type, payload } = event.data || {};
+
+        try {
+          switch (type) {
+            case 'ping':
+              handlePing(payload);
+              break;
+
+            case 'eval':
+              handleEval(payload);
+              break;
+
+            case 'render':
+              // Skip inline rendering if React renderer is active
+              if (window.__REACT_RENDERER_ACTIVE__) return;
+              handleRender(payload);
+              break;
+
+            case 'theme':
+              // Skip inline theme handling if React renderer is active
+              if (window.__REACT_RENDERER_ACTIVE__) return;
+              handleTheme(payload);
+              break;
+
+            case 'clear':
+              // Skip inline clear if React renderer is active
+              if (window.__REACT_RENDERER_ACTIVE__) return;
+              handleClear();
+              break;
+
+            case 'widget_state':
+              handleWidgetState(payload);
+              break;
+
+            // Comm bridge messages - handled by React widget system, ignore here
+            case 'bridge_ready':
+            case 'comm_open':
+            case 'comm_msg':
+            case 'comm_close':
+            case 'comm_sync':
+              // These are handled by widget-bridge-client.ts
+              break;
+
+            default:
+              console.warn('[frame] Unknown message type:', type);
+          }
+        } catch (err) {
+          sendError(err);
+        }
+      });
+
+      // --- Message Handlers ---
+
+      function handlePing(payload) {
+        send('pong', {
+          receivedAt: Date.now(),
+          echo: payload
+        });
+      }
+
+      function handleEval(payload) {
+        const { code } = payload || {};
+        if (!code) {
+          send('eval_result', { success: false, error: 'No code provided' });
+          return;
+        }
+
+        // Store the current message for access during eval
+        window.currentMessage = event;
+        try {
+          const result = eval.call(null, code);
+          send('eval_result', { success: true, result: String(result ?? 'undefined') });
+        } catch (err) {
+          send('eval_result', { success: false, error: err.message });
+        } finally {
+          delete window.currentMessage;
+        }
+      }
+
+      function handleRender(payload) {
+        const { mimeType, data, metadata, append } = payload || {};
+
+        // Create output container
+        const output = document.createElement('div');
+        output.className = 'output-item';
+        output.style.marginBottom = '8px';
+
+        if (mimeType === 'text/html') {
+          // Use createContextualFragment for proper script execution
+          const range = document.createRange();
+          const fragment = range.createContextualFragment(String(data));
+          output.appendChild(fragment);
+        } else if (mimeType === 'text/plain') {
+          const pre = document.createElement('pre');
+          // Handle ANSI escape codes for colored output
+          pre.innerHTML = parseAnsi(String(data));
+          output.appendChild(pre);
+        } else if (mimeType === 'image/svg+xml') {
+          // SVG: render inline
+          const container = document.createElement('div');
+          container.innerHTML = String(data);
+          const svg = container.querySelector('svg');
+          if (svg) {
+            svg.style.maxWidth = '100%';
+            svg.style.height = 'auto';
+            output.appendChild(svg);
+          } else {
+            output.appendChild(container);
+          }
+        } else if (mimeType && mimeType.startsWith('image/')) {
+          const img = document.createElement('img');
+          const imgData = String(data);
+          // Check if it's base64 or a URL
+          if (imgData.startsWith('data:') || imgData.startsWith('http')) {
+            img.src = imgData;
+          } else {
+            img.src = 'data:' + mimeType + ';base64,' + imgData;
+          }
+          if (metadata?.width) img.width = metadata.width;
+          if (metadata?.height) img.height = metadata.height;
+          output.appendChild(img);
+        } else if (mimeType === 'application/json') {
+          // JSON: render as formatted, collapsible tree
+          const pre = document.createElement('pre');
+          try {
+            const parsed = typeof data === 'string' ? JSON.parse(data) : data;
+            pre.textContent = JSON.stringify(parsed, null, 2);
+          } catch (e) {
+            pre.textContent = String(data);
+          }
+          output.appendChild(pre);
+        } else {
+          // Fallback: render as text
+          const pre = document.createElement('pre');
+          pre.textContent = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+          output.appendChild(pre);
+        }
+
+        // Append or replace
+        if (append) {
+          root.appendChild(output);
+        } else {
+          root.innerHTML = '';
+          root.appendChild(output);
+        }
+
+        // Notify completion
+        requestAnimationFrame(function() {
+          send('render_complete', { height: document.body.scrollHeight });
+        });
+      }
+
+      // Basic ANSI escape code parser
+      function parseAnsi(text) {
+        // Simple ANSI color mapping
+        const colors = {
+          '30': '#000', '31': '#e74c3c', '32': '#2ecc71', '33': '#f1c40f',
+          '34': '#3498db', '35': '#9b59b6', '36': '#1abc9c', '37': '#ecf0f1',
+          '90': '#7f8c8d', '91': '#e74c3c', '92': '#2ecc71', '93': '#f1c40f',
+          '94': '#3498db', '95': '#9b59b6', '96': '#1abc9c', '97': '#fff'
+        };
+
+        // Escape HTML
+        let result = text
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+
+        // Parse ANSI codes
+        result = result.replace(/\\x1b\\[(\\d+(?:;\\d+)*)m/g, function(match, codes) {
+          const codeList = codes.split(';');
+          let style = '';
+          for (const code of codeList) {
+            if (code === '0') return '</span>';
+            if (code === '1') style += 'font-weight:bold;';
+            if (code === '3') style += 'font-style:italic;';
+            if (code === '4') style += 'text-decoration:underline;';
+            if (colors[code]) style += 'color:' + colors[code] + ';';
+          }
+          return style ? '<span style="' + style + '">' : '';
+        });
+
+        // Also handle \\e[ format
+        result = result.replace(/\\e\\[(\\d+(?:;\\d+)*)m/g, function(match, codes) {
+          const codeList = codes.split(';');
+          let style = '';
+          for (const code of codeList) {
+            if (code === '0') return '</span>';
+            if (code === '1') style += 'font-weight:bold;';
+            if (colors[code]) style += 'color:' + colors[code] + ';';
+          }
+          return style ? '<span style="' + style + '">' : '';
+        });
+
+        return result;
+      }
+
+      function handleTheme(payload) {
+        const { isDark, cssVariables } = payload || {};
+        const rootEl = document.documentElement;
+
+        if (isDark !== undefined) {
+          rootEl.style.setProperty('--bg-primary', isDark ? '#0a0a0a' : '#ffffff');
+          rootEl.style.setProperty('--bg-secondary', isDark ? '#1a1a1a' : '#f5f5f5');
+          rootEl.style.setProperty('--text-primary', isDark ? '#e0e0e0' : '#1a1a1a');
+          rootEl.style.setProperty('--text-secondary', isDark ? '#a0a0a0' : '#666666');
+          rootEl.style.setProperty('--border-color', isDark ? '#333333' : '#e0e0e0');
+        }
+
+        if (cssVariables) {
+          Object.entries(cssVariables).forEach(function([key, value]) {
+            rootEl.style.setProperty(key, value);
+          });
+        }
+      }
+
+      function handleClear() {
+        root.innerHTML = '';
+        send('render_complete', { height: document.body.scrollHeight });
+      }
+
+      function handleWidgetState(payload) {
+        // Widget state updates are handled by the injected renderer bundle
+        // This is a placeholder that fires a custom event
+        window.dispatchEvent(new CustomEvent('widget_state', { detail: payload }));
+      }
+
+      // --- Utilities ---
+
+      function send(type, payload) {
+        window.parent.postMessage({ type: type, payload: payload }, '*');
+      }
+
+      function sendError(err) {
+        send('error', {
+          message: err.message || String(err),
+          stack: err.stack
+        });
+      }
+
+      // --- Resize Observer ---
+      const resizeObserver = new ResizeObserver(function(entries) {
+        const height = document.body.scrollHeight;
+        send('resize', { height: height });
+      });
+      resizeObserver.observe(document.body);
+
+      // --- Link Click Interception ---
+      document.addEventListener('click', function(e) {
+        const link = e.target.closest('a');
+        if (link && link.href) {
+          e.preventDefault();
+          send('link_click', {
+            url: link.href,
+            newTab: e.metaKey || e.ctrlKey
+          });
+        }
+      });
+
+      // --- Double Click Forwarding ---
+      document.addEventListener('dblclick', function(e) {
+        // Don't forward double-clicks on links (user is selecting text)
+        const link = e.target.closest('a');
+        if (!link) {
+          send('dblclick', null);
+        }
+      });
+
+      // --- Error Handler ---
+      window.addEventListener('error', function(e) {
+        sendError(e.error || new Error(e.message));
+      });
+
+      window.addEventListener('unhandledrejection', function(e) {
+        sendError(e.reason || new Error('Unhandled promise rejection'));
+      });
+
+      // --- Additional Script ---
+      ${additionalScript}
+
+      // --- Ready Signal ---
+      isReady = true;
+      send('ready', null);
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * Create a blob URL from the frame HTML.
+ *
+ * @param options - Configuration options for the frame
+ * @returns A blob: URL that can be used as iframe src
+ */
+export function createFrameBlobUrl(options?: FrameHtmlOptions): string {
+  const html = generateFrameHtml(options);
+  const blob = new Blob([html], { type: "text/html" });
+  return URL.createObjectURL(blob);
+}

--- a/registry/outputs/isolated/index.ts
+++ b/registry/outputs/isolated/index.ts
@@ -1,0 +1,38 @@
+// Production components
+
+// Widget comm bridge for isolated frames
+export {
+  CommBridgeManager,
+  createCommBridgeManager,
+} from "./comm-bridge-manager";
+// Message protocol types
+export type {
+  ClearMessage,
+  EvalMessage,
+  EvalResultMessage,
+  IframeErrorMessage,
+  // Utilities
+  IframeMessage,
+  // Iframe → Parent
+  IframeToParentMessage,
+  LinkClickMessage,
+  MessageType,
+  // Parent → Iframe
+  ParentToIframeMessage,
+  PingMessage,
+  PongMessage,
+  ReadyMessage,
+  RenderCompleteMessage,
+  RenderMessage,
+  RenderPayload,
+  ResizeMessage,
+  ThemeMessage,
+  WidgetStateMessage,
+  WidgetUpdateMessage,
+} from "./frame-bridge";
+export { isIframeMessage, isMessageType } from "./frame-bridge";
+export type { FrameHtmlOptions } from "./frame-html";
+// HTML template generator
+export { createFrameBlobUrl, generateFrameHtml } from "./frame-html";
+export type { IsolatedFrameHandle, IsolatedFrameProps } from "./isolated-frame";
+export { IsolatedFrame } from "./isolated-frame";

--- a/registry/outputs/isolated/isolated-frame.tsx
+++ b/registry/outputs/isolated/isolated-frame.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import type {
+  IframeToParentMessage,
+  ParentToIframeMessage,
+  RenderPayload,
+} from "./frame-bridge";
+import { isIframeMessage } from "./frame-bridge";
+import { createFrameBlobUrl } from "./frame-html";
+
+export interface IsolatedFrameProps {
+  /**
+   * Unique ID for this frame (used for message routing).
+   */
+  id?: string;
+
+  /**
+   * Initial content to render when the frame is ready.
+   */
+  initialContent?: RenderPayload;
+
+  /**
+   * Whether to use dark mode styling.
+   */
+  darkMode?: boolean;
+
+  /**
+   * Whether to bootstrap the React renderer bundle.
+   * When true, fetches and evals the isolated-renderer bundle after the iframe is ready.
+   * The bundle provides full React-based output rendering with MediaRouter support.
+   * @default false
+   */
+  useReactRenderer?: boolean;
+
+  /**
+   * Minimum height of the iframe in pixels.
+   * @default 24
+   */
+  minHeight?: number;
+
+  /**
+   * Maximum height of the iframe in pixels.
+   * @default 2000
+   */
+  maxHeight?: number;
+
+  /**
+   * Additional CSS classes for the iframe container.
+   */
+  className?: string;
+
+  /**
+   * Callback when the iframe is ready to receive messages.
+   */
+  onReady?: () => void;
+
+  /**
+   * Callback when the iframe content resizes.
+   */
+  onResize?: (height: number) => void;
+
+  /**
+   * Callback when a link is clicked in the iframe.
+   */
+  onLinkClick?: (url: string, newTab: boolean) => void;
+
+  /**
+   * Callback when the user double-clicks in the iframe.
+   */
+  onDoubleClick?: () => void;
+
+  /**
+   * Callback when a widget state update is sent from the iframe.
+   */
+  onWidgetUpdate?: (commId: string, state: Record<string, unknown>) => void;
+
+  /**
+   * Callback when an error occurs in the iframe.
+   */
+  onError?: (error: { message: string; stack?: string }) => void;
+
+  /**
+   * Callback for all messages from the iframe (for debugging or custom handling).
+   */
+  onMessage?: (message: IframeToParentMessage) => void;
+}
+
+export interface IsolatedFrameHandle {
+  /**
+   * Send a message to the iframe.
+   */
+  send: (message: ParentToIframeMessage) => void;
+
+  /**
+   * Send content to render in the iframe.
+   */
+  render: (payload: RenderPayload) => void;
+
+  /**
+   * Evaluate code in the iframe (for bootstrap/injection).
+   */
+  eval: (code: string) => void;
+
+  /**
+   * Update theme settings in the iframe.
+   */
+  setTheme: (isDark: boolean) => void;
+
+  /**
+   * Clear all content in the iframe.
+   */
+  clear: () => void;
+
+  /**
+   * Whether the iframe is ready to receive messages.
+   * When useReactRenderer is true, this is true after the React bundle is initialized.
+   * When useReactRenderer is false, this is true after the inline renderer is ready.
+   */
+  isReady: boolean;
+
+  /**
+   * Whether the iframe bootstrap HTML is loaded.
+   * This is true before the React renderer bundle is loaded (if useReactRenderer is true).
+   */
+  isIframeReady: boolean;
+}
+
+/**
+ * Sandbox attributes for the isolated iframe.
+ *
+ * CRITICAL: Do NOT include 'allow-same-origin' - this would give the iframe
+ * access to the parent's origin and Tauri APIs.
+ */
+const SANDBOX_ATTRS = [
+  "allow-scripts", // Required for rendering interactive content
+  "allow-downloads", // Allow file downloads (e.g., from widgets)
+  "allow-forms", // Allow form submissions
+  "allow-pointer-lock", // For interactive visualizations
+  "allow-popups", // Allow window.open (for links)
+  "allow-popups-to-escape-sandbox", // Popups should be unrestricted
+  "allow-modals", // Allow alert/confirm/prompt
+].join(" ");
+
+/**
+ * IsolatedFrame component - Renders untrusted content in a secure iframe.
+ *
+ * Uses a blob: URL with sandbox restrictions to ensure the iframe content
+ * cannot access Tauri APIs or the parent DOM. Communication happens via
+ * postMessage.
+ *
+ * @example
+ * ```tsx
+ * const frameRef = useRef<IsolatedFrameHandle>(null);
+ *
+ * <IsolatedFrame
+ *   ref={frameRef}
+ *   darkMode={true}
+ *   onReady={() => {
+ *     frameRef.current?.render({
+ *       mimeType: "text/html",
+ *       data: "<h1>Hello from isolated frame!</h1>"
+ *     });
+ *   }}
+ *   onResize={(height) => console.log("New height:", height)}
+ * />
+ * ```
+ */
+/**
+ * Cache for the renderer bundle to avoid re-fetching.
+ */
+let rendererBundleCache: string | null = null;
+let rendererCssCache: string | null = null;
+
+/**
+ * Fetch the React renderer bundle and CSS.
+ */
+async function fetchRendererBundle(): Promise<{ js: string; css: string }> {
+  if (rendererBundleCache && rendererCssCache) {
+    return { js: rendererBundleCache, css: rendererCssCache };
+  }
+
+  const [jsResponse, cssResponse] = await Promise.all([
+    fetch("/isolated/isolated-renderer.js"),
+    fetch("/isolated/isolated-renderer.css"),
+  ]);
+
+  if (!jsResponse.ok) {
+    throw new Error(`Failed to fetch renderer bundle: ${jsResponse.status}`);
+  }
+  if (!cssResponse.ok) {
+    throw new Error(`Failed to fetch renderer CSS: ${cssResponse.status}`);
+  }
+
+  const [js, css] = await Promise.all([jsResponse.text(), cssResponse.text()]);
+
+  rendererBundleCache = js;
+  rendererCssCache = css;
+
+  return { js, css };
+}
+
+export const IsolatedFrame = forwardRef<
+  IsolatedFrameHandle,
+  IsolatedFrameProps
+>(function IsolatedFrame(
+  {
+    id,
+    initialContent,
+    darkMode = true,
+    useReactRenderer = false,
+    minHeight = 24,
+    maxHeight = 2000,
+    className = "",
+    onReady,
+    onResize,
+    onLinkClick,
+    onDoubleClick,
+    onWidgetUpdate,
+    onError,
+    onMessage,
+  },
+  ref,
+) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  // Track iframe ready (bootstrap HTML loaded)
+  const [isIframeReady, setIsIframeReady] = useState(false);
+  // Track renderer ready (React bundle initialized, or inline renderer if not using React)
+  const [isReady, setIsReady] = useState(false);
+  // Use ref to track ready state for send callback (avoids stale closure)
+  const isReadyRef = useRef(false);
+  const [height, setHeight] = useState(minHeight);
+
+  // Queue messages until iframe is ready
+  const pendingMessagesRef = useRef<ParentToIframeMessage[]>([]);
+  // Track if we've started bootstrapping to avoid double-fetch
+  const bootstrappingRef = useRef(false);
+
+  // Track initial darkMode for blob URL (don't recreate blob on theme change)
+  const initialDarkModeRef = useRef(darkMode);
+
+  // Create blob URL on mount (only once, with initial darkMode)
+  useEffect(() => {
+    const url = createFrameBlobUrl({ darkMode: initialDarkModeRef.current });
+    setBlobUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, []);
+
+  // Forward theme changes to iframe (without recreating the blob)
+  useEffect(() => {
+    if (isReady && iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage(
+        { type: "theme", payload: { isDark: darkMode } },
+        "*",
+      );
+    }
+  }, [darkMode, isReady]);
+
+  // Keep ref in sync with state (ref avoids stale closures in callbacks)
+  useEffect(() => {
+    isReadyRef.current = isReady;
+  }, [isReady]);
+
+  // Send a message to the iframe
+  // Uses ref to check ready state to avoid stale closure issues
+  const send = useCallback(
+    (message: ParentToIframeMessage) => {
+      if (!isReadyRef.current) {
+        // Queue message until ready
+        pendingMessagesRef.current.push(message);
+        return;
+      }
+
+      if (iframeRef.current?.contentWindow) {
+        iframeRef.current.contentWindow.postMessage(message, "*");
+      }
+    },
+    [], // No deps - uses ref instead of state
+  );
+
+  // Flush pending messages when ready
+  useEffect(() => {
+    if (isReady && pendingMessagesRef.current.length > 0) {
+      const pending = pendingMessagesRef.current;
+      pendingMessagesRef.current = [];
+      pending.forEach((msg) => {
+        if (iframeRef.current?.contentWindow) {
+          iframeRef.current.contentWindow.postMessage(msg, "*");
+        }
+      });
+    }
+  }, [isReady]);
+
+  // Handle messages from iframe
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // Verify the message is from our iframe
+      if (event.source !== iframeRef.current?.contentWindow) {
+        return;
+      }
+
+      const data = event.data;
+      if (!isIframeMessage(data)) {
+        return;
+      }
+
+      // Call generic message handler
+      onMessage?.(data);
+
+      // Handle specific message types
+      switch (data.type) {
+        case "ready":
+          // Iframe bootstrap HTML is loaded
+          setIsIframeReady(true);
+
+          if (useReactRenderer) {
+            // Bootstrap the React renderer if not already doing so
+            if (!bootstrappingRef.current) {
+              bootstrappingRef.current = true;
+              fetchRendererBundle()
+                .then(({ js, css }) => {
+                  // Inject CSS first
+                  const cssCode = `
+                      (function() {
+                        var style = document.createElement('style');
+                        style.textContent = ${JSON.stringify(css)};
+                        document.head.appendChild(style);
+                      })();
+                    `;
+                  iframeRef.current?.contentWindow?.postMessage(
+                    { type: "eval", payload: { code: cssCode } },
+                    "*",
+                  );
+                  // Then inject JS bundle
+                  iframeRef.current?.contentWindow?.postMessage(
+                    { type: "eval", payload: { code: js } },
+                    "*",
+                  );
+                })
+                .catch((err) => {
+                  console.error(
+                    "[IsolatedFrame] Failed to load renderer:",
+                    err,
+                  );
+                  onError?.({ message: err.message });
+                  // Fall back to inline renderer
+                  setIsReady(true);
+                  onReady?.();
+                });
+            }
+          } else {
+            // Using inline renderer, mark as ready immediately
+            setIsReady(true);
+            onReady?.();
+            // Render initial content if provided
+            if (initialContent) {
+              iframeRef.current?.contentWindow?.postMessage(
+                { type: "render", payload: initialContent },
+                "*",
+              );
+            }
+          }
+          break;
+
+        case "renderer_ready":
+          // React renderer bundle is initialized
+          setIsReady(true);
+          onReady?.();
+          // Render initial content if provided
+          if (initialContent) {
+            iframeRef.current?.contentWindow?.postMessage(
+              { type: "render", payload: initialContent },
+              "*",
+            );
+          }
+          break;
+
+        case "resize":
+          if (data.payload?.height != null) {
+            const newHeight = Math.max(
+              minHeight,
+              Math.min(maxHeight, data.payload.height),
+            );
+            setHeight(newHeight);
+            onResize?.(newHeight);
+          }
+          break;
+
+        case "link_click":
+          if (data.payload?.url) {
+            onLinkClick?.(data.payload.url, data.payload.newTab ?? false);
+          }
+          break;
+
+        case "dblclick":
+          onDoubleClick?.();
+          break;
+
+        case "widget_update":
+          if (data.payload?.commId && data.payload?.state) {
+            onWidgetUpdate?.(data.payload.commId, data.payload.state);
+          }
+          break;
+
+        case "error":
+          if (data.payload) {
+            onError?.(data.payload);
+          }
+          break;
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [
+    initialContent,
+    minHeight,
+    maxHeight,
+    useReactRenderer,
+    onReady,
+    onResize,
+    onLinkClick,
+    onDoubleClick,
+    onWidgetUpdate,
+    onError,
+    onMessage,
+  ]);
+
+  // Expose imperative API
+  useImperativeHandle(
+    ref,
+    () => ({
+      send,
+      render: (payload: RenderPayload) => send({ type: "render", payload }),
+      eval: (code: string) => send({ type: "eval", payload: { code } }),
+      setTheme: (isDark: boolean) =>
+        send({ type: "theme", payload: { isDark } }),
+      clear: () => send({ type: "clear" }),
+      isReady,
+      isIframeReady,
+    }),
+    [send, isReady, isIframeReady],
+  );
+
+  if (!blobUrl) {
+    return null;
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      id={id}
+      src={blobUrl}
+      sandbox={SANDBOX_ATTRS}
+      className={className}
+      style={{
+        width: "100%",
+        height: `${height}px`,
+        border: "none",
+        display: "block",
+      }}
+      title="Isolated output frame"
+    />
+  );
+});


### PR DESCRIPTION
## Summary

Adds a system for rendering untrusted output content in sandboxed iframes:

- **IsolatedFrame**: React component for secure iframe rendering using blob URLs with sandbox restrictions
- **frame-bridge**: Message protocol types for parent↔iframe communication (render, theme, widget state, etc.)
- **frame-html**: HTML template generator with CSP, message handlers, and ResizeObserver
- **comm-bridge-manager**: Widget comm bridge for Jupyter widget protocol in iframes

This is part of PR 4 of the bandung-v2 → cayenne sync effort.

## Security

The iframe uses blob: URLs with sandbox restrictions (critically, no `allow-same-origin`) to prevent iframe content from accessing:
- Tauri APIs (in desktop contexts)
- Parent DOM
- Local storage
- Cookies

All communication happens via postMessage with a typed protocol.

## Test plan

- [x] Verify types:check passes
- [x] Verify lint passes
- [x] Test that IsolatedFrame renders HTML content correctly
- [x] Test theme propagation (dark/light mode)
- [x] Test resize observer auto-sizing