### PR TITLE
Add IsolatedFrame integration to OutputArea

### DIFF
--- a/registry/cell/OutputArea.tsx
+++ b/registry/cell/OutputArea.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { type ReactNode, useId } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import { cn } from "@/lib/utils";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
 } from "@/registry/outputs/ansi-output";
-import { MediaRouter } from "@/registry/outputs/media-router";
+import { isDarkMode as detectDarkMode } from "@/registry/outputs/dark-mode";
+import {
+  CommBridgeManager,
+  type IframeToParentMessage,
+  IsolatedFrame,
+  type IsolatedFrameHandle,
+} from "@/registry/outputs/isolated";
+import { DEFAULT_PRIORITY, MediaRouter } from "@/registry/outputs/media-router";
+import { useWidgetStore } from "@/registry/widgets/widget-store-context";
 
 /**
  * Jupyter output types based on the nbformat spec.
@@ -72,6 +87,28 @@ interface OutputAreaProps {
    * Whether to allow unsafe HTML rendering.
    */
   unsafe?: boolean;
+  /**
+   * Force isolation mode. When true, all outputs render in an isolated iframe.
+   * When "auto" (default), isolation is used when any output needs it.
+   * When false, outputs render in-DOM (less secure but faster for simple outputs).
+   */
+  isolated?: boolean | "auto";
+  /**
+   * Pre-create the IsolatedFrame even when there are no outputs.
+   * This allows the iframe to bootstrap ahead of time, making output rendering instant.
+   * The iframe is hidden until outputs that need isolation arrive.
+   * @default false
+   */
+  preloadIframe?: boolean;
+  /**
+   * Callback when a link is clicked in isolated outputs.
+   */
+  onLinkClick?: (url: string, newTab: boolean) => void;
+  /**
+   * Callback when widget state is updated in isolated outputs.
+   * @deprecated Use the comm bridge instead for full widget support
+   */
+  onWidgetUpdate?: (commId: string, state: Record<string, unknown>) => void;
 }
 
 /**
@@ -79,6 +116,88 @@ interface OutputAreaProps {
  */
 function normalizeText(text: string | string[]): string {
   return Array.isArray(text) ? text.join("") : text;
+}
+
+/**
+ * MIME types that require iframe isolation for security.
+ * These types can contain executable scripts or interactive content.
+ */
+const ISOLATED_MIME_TYPES = new Set([
+  "text/html",
+  "text/markdown",
+  "image/svg+xml",
+  "application/vnd.jupyter.widget-view+json",
+  "application/vnd.plotly.v1+json",
+  "application/vnd.vegalite.v5+json",
+  "application/vnd.vegalite.v4+json",
+  "application/vnd.vegalite.v3+json",
+  "application/vnd.vega.v5+json",
+  "application/vnd.vega.v4+json",
+]);
+
+/**
+ * Select the best MIME type from available data based on priority.
+ */
+function selectMimeType(
+  data: Record<string, unknown>,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): string | null {
+  const availableTypes = Object.keys(data);
+  for (const mimeType of priority) {
+    if (availableTypes.includes(mimeType) && data[mimeType] != null) {
+      return mimeType;
+    }
+  }
+  const firstAvailable = availableTypes.find((type) => data[type] != null);
+  return firstAvailable || null;
+}
+
+/**
+ * Check if a single output needs iframe isolation.
+ */
+function outputNeedsIsolation(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  if (
+    output.output_type === "execute_result" ||
+    output.output_type === "display_data"
+  ) {
+    const mimeType = selectMimeType(output.data, priority);
+    return mimeType ? ISOLATED_MIME_TYPES.has(mimeType) : false;
+  }
+  // stream and error outputs don't need isolation
+  return false;
+}
+
+/**
+ * Check if any outputs in the array need iframe isolation.
+ * If any output needs isolation, ALL outputs should go to the iframe.
+ */
+function anyOutputNeedsIsolation(
+  outputs: JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return outputs.some((output) => outputNeedsIsolation(output, priority));
+}
+
+/**
+ * Check if outputs contain any widget MIME types.
+ */
+function hasWidgetOutputs(
+  outputs: JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return outputs.some((output) => {
+    if (
+      output.output_type === "execute_result" ||
+      output.output_type === "display_data"
+    ) {
+      const mimeType = selectMimeType(output.data, priority);
+      return mimeType === "application/vnd.jupyter.widget-view+json";
+    }
+    return false;
+  });
 }
 
 /**
@@ -159,21 +278,164 @@ export function OutputArea({
   maxHeight,
   className,
   renderers,
-  priority,
+  priority = DEFAULT_PRIORITY,
   unsafe = false,
+  isolated = "auto",
+  preloadIframe = false,
+  onLinkClick,
+  onWidgetUpdate,
 }: OutputAreaProps) {
   const id = useId();
+  const frameRef = useRef<IsolatedFrameHandle>(null);
+  const bridgeRef = useRef<CommBridgeManager | null>(null);
 
-  // Empty state: render nothing
-  if (outputs.length === 0) {
-    return null;
-  }
+  // Track dark mode state and observe changes
+  const [darkMode, setDarkMode] = useState(() => detectDarkMode());
+
+  useEffect(() => {
+    // Update dark mode when document class changes
+    const observer = new MutationObserver(() => {
+      setDarkMode(detectDarkMode());
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "data-mode"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  // Get widget store context (may be null if not in provider)
+  const widgetContext = useWidgetStore();
+
+  // Determine if we should use isolation (when we have outputs)
+  const shouldIsolate =
+    outputs.length > 0 &&
+    (isolated === true ||
+      (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
+
+  // When preloading, we render the iframe even with no outputs (hidden)
+  // This allows it to bootstrap ahead of time for instant rendering
+  const showPreloadedIframe = preloadIframe && !collapsed;
+
+  // Check if we have widgets and should set up comm bridge
+  const hasWidgets = hasWidgetOutputs(outputs, priority);
+  const shouldUseBridge = shouldIsolate && hasWidgets && widgetContext !== null;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
   const outputCount = outputs.length;
 
+  // Handle messages from iframe, routing widget messages to comm bridge
+  const handleIframeMessage = useCallback(
+    (message: IframeToParentMessage) => {
+      // Route widget messages to bridge
+      if (bridgeRef.current) {
+        bridgeRef.current.handleIframeMessage(message);
+      }
+
+      // Also handle widget_update for backward compatibility
+      if (message.type === "widget_update" && onWidgetUpdate) {
+        onWidgetUpdate(message.payload.commId, message.payload.state);
+      }
+    },
+    [onWidgetUpdate],
+  );
+
+  // Callback when frame is ready - set up bridge and render outputs
+  const handleFrameReady = useCallback(() => {
+    if (!frameRef.current) return;
+
+    // Set up comm bridge if we have widgets and widget context
+    if (shouldUseBridge && widgetContext && !bridgeRef.current) {
+      bridgeRef.current = new CommBridgeManager({
+        frame: frameRef.current,
+        store: widgetContext.store,
+        sendUpdate: widgetContext.sendUpdate,
+        sendCustom: widgetContext.sendCustom,
+        closeComm: widgetContext.closeComm,
+      });
+    }
+
+    // Clear existing content
+    frameRef.current.clear();
+
+    // Render each output
+    outputs.forEach((output, index) => {
+      const append = index > 0;
+
+      if (
+        output.output_type === "execute_result" ||
+        output.output_type === "display_data"
+      ) {
+        const mimeType = selectMimeType(output.data, priority);
+        if (mimeType) {
+          frameRef.current?.render({
+            mimeType,
+            data: output.data[mimeType],
+            metadata: output.metadata?.[mimeType] as
+              | Record<string, unknown>
+              | undefined,
+            outputIndex: index,
+            append,
+          });
+        }
+      } else if (output.output_type === "stream") {
+        frameRef.current?.render({
+          mimeType: "text/plain",
+          data: normalizeText(output.text),
+          metadata: { streamName: output.name },
+          outputIndex: index,
+          append,
+        });
+      } else if (output.output_type === "error") {
+        // Render error with metadata so iframe can use AnsiErrorOutput
+        frameRef.current?.render({
+          mimeType: "text/plain",
+          data: output.traceback.join("\n"),
+          metadata: {
+            isError: true,
+            ename: output.ename,
+            evalue: output.evalue,
+            traceback: output.traceback,
+          },
+          outputIndex: index,
+          append,
+        });
+      }
+    });
+  }, [outputs, priority, shouldUseBridge, widgetContext]);
+
+  // Clean up bridge on unmount
+  useEffect(() => {
+    return () => {
+      if (bridgeRef.current) {
+        bridgeRef.current.dispose();
+        bridgeRef.current = null;
+      }
+    };
+  }, []);
+
+  // Re-render outputs when they change (after initial ready)
+  useEffect(() => {
+    if (frameRef.current?.isReady) {
+      handleFrameReady();
+    }
+  }, [handleFrameReady]);
+
+  // Empty state: render nothing (unless preloading iframe)
+  if (outputs.length === 0 && !showPreloadedIframe) {
+    return null;
+  }
+
+  // Hide the entire output area when only preloading (no visible outputs)
+  const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
+
   return (
-    <div data-slot="output-area" className={cn("output-area", className)}>
+    <div
+      data-slot="output-area"
+      className={cn("output-area", isPreloadOnly && "hidden", className)}
+    >
       {/* Collapse toggle */}
       {hasCollapseControl && (
         <button
@@ -203,9 +465,31 @@ export function OutputArea({
           className={cn("space-y-2", maxHeight && "overflow-y-auto")}
           style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}
         >
-          {outputs.map((output, index) =>
-            renderOutput(output, index, renderers, priority, unsafe),
+          {/* Preloaded or active isolated frame */}
+          {(shouldIsolate || showPreloadedIframe) && (
+            <div className={shouldIsolate ? undefined : "hidden"}>
+              <IsolatedFrame
+                ref={frameRef}
+                darkMode={darkMode}
+                useReactRenderer={true}
+                minHeight={24}
+                maxHeight={maxHeight ?? 2000}
+                onReady={handleFrameReady}
+                onLinkClick={onLinkClick}
+                onWidgetUpdate={onWidgetUpdate}
+                onMessage={handleIframeMessage}
+                onError={(err) =>
+                  console.error("[OutputArea] iframe error:", err)
+                }
+              />
+            </div>
           )}
+
+          {/* In-DOM outputs (when not using isolation) */}
+          {!shouldIsolate &&
+            outputs.map((output, index) =>
+              renderOutput(output, index, renderers, priority, unsafe),
+            )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Updates OutputArea.tsx to use the IsolatedFrame for outputs that need security isolation:

- **New props**:
  - `isolated`: Control isolation mode (`"auto"` | `true` | `false`)
  - `preloadIframe`: Eager iframe bootstrap for instant rendering
  - `onLinkClick`: Callback for link clicks in isolated content
  - `onWidgetUpdate`: Callback for widget state updates

- **IsolatedFrame integration**:
  - Routes HTML, SVG, Markdown, widgets, and visualization outputs to secure iframe
  - Integrates CommBridgeManager for Jupyter widget comm protocol
  - Dark mode MutationObserver syncs theme to iframe

- **New helpers**:
  - `ISOLATED_MIME_TYPES` set for determining isolation requirements
  - `outputNeedsIsolation()`, `anyOutputNeedsIsolation()`, `hasWidgetOutputs()`

This completes the IsolatedFrame integration started in #151.

## Test plan

- [x] Verify types:check passes
- [x] Verify lint passes
- [x] Test HTML output renders in iframe
- [x] Test widgets render via comm bridge
- [x] Test dark mode propagates to iframe