### PR TITLE
fix: Only show ValidWidget readout on validation failure

### DIFF
--- a/registry/widgets/controls/valid-widget.tsx
+++ b/registry/widgets/controls/valid-widget.tsx
@@ -29,7 +29,7 @@ export function ValidWidget({ modelId, className }: WidgetComponentProps) {
       ) : (
         <XIcon className="size-4 text-red-500" />
       )}
-      {readout && (
+      {!value && readout && (
         <span className="text-sm text-muted-foreground">{readout}</span>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fix ValidWidget to only display the readout text when validation fails (`value === false`), matching ipywidgets behavior.

## Change

```diff
- {readout && (
+ {!value && readout && (
```

The readout is meant to show error/validation messages, so it should only appear when the validation state is false (showing the X icon).

## Before/After

**Before**: Readout text always visible when set
**After**: Readout text only visible when validation fails