### PR TITLE
Fix keyboard navigation in markdown cell view mode

### DIFF
--- a/registry/cell/MarkdownCell.tsx
+++ b/registry/cell/MarkdownCell.tsx
@@ -137,6 +137,7 @@ export function MarkdownCell({
   const [editing, setEditing] = useState(cell.source === "");
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const frameRef = useRef<IsolatedFrameHandle>(null);
+  const viewRef = useRef<HTMLDivElement>(null);
 
   // Optional editor registry for cross-cell navigation
   const registry = useEditorRegistryOptional();
@@ -205,6 +206,28 @@ export function MarkdownCell({
     window.open(url, "_blank", "noopener,noreferrer");
   }, []);
 
+  // Handle keyboard navigation in view mode (when not editing)
+  const handleViewKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        onFocusNext?.("start");
+        e.preventDefault();
+      } else if (e.key === "ArrowUp") {
+        onFocusPrevious?.("end");
+        e.preventDefault();
+      } else if (e.key === "Enter" && e.shiftKey) {
+        // Shift+Enter: move to next cell (like execute for code cells)
+        onFocusNext?.("start");
+        e.preventDefault();
+      } else if (e.key === "Enter" && !e.shiftKey) {
+        // Enter: enter edit mode
+        setEditing(true);
+        e.preventDefault();
+      }
+    },
+    [onFocusNext, onFocusPrevious],
+  );
+
   // Handle focus next, creating a new cell if at the end
   const handleFocusNextOrCreate = useCallback(
     (cursorPosition: "start" | "end") => {
@@ -260,6 +283,15 @@ export function MarkdownCell({
     }
   }, [editing]);
 
+  // Focus view section when cell becomes focused but not editing
+  useEffect(() => {
+    if (isFocused && !editing) {
+      requestAnimationFrame(() => {
+        viewRef.current?.focus();
+      });
+    }
+  }, [isFocused, editing]);
+
   return (
     <CellContainer
       id={cell.id}
@@ -303,11 +335,17 @@ export function MarkdownCell({
 
       {/* View section - hidden when editing */}
       <div
+        ref={viewRef}
+        role="textbox"
+        aria-readonly
+        aria-label="Markdown cell content"
+        tabIndex={0}
         className={cn(
-          "py-2 cursor-text relative group/md",
+          "py-2 cursor-text relative group/md outline-none",
           editing && "hidden",
         )}
         onDoubleClick={handleDoubleClick}
+        onKeyDown={handleViewKeyDown}
       >
         {cell.source ? (
           <IsolatedFrame


### PR DESCRIPTION
## Summary

Fixes keyboard navigation getting stuck when a markdown cell is in view mode (rendered, not editing).

## Problem

When pressing Shift+Enter in edit mode, the cell exits editing and focuses the next cell. But that next cell is now in view mode with no editor to capture keyboard events - arrow keys and Shift+Enter do nothing.

## Solution

Add keyboard handling at the view section level:

| Key | Action |
|-----|--------|
| `ArrowDown` | Focus next cell |
| `ArrowUp` | Focus previous cell |
| `Shift+Enter` | Focus next cell (like execute for code) |
| `Enter` | Enter edit mode |

Changes:
- Add `viewRef` for the view section
- Add `handleViewKeyDown` callback for navigation
- Auto-focus view section when cell becomes focused but not editing
- Add `role="textbox"` and ARIA attributes for accessibility

## Related

This bug also exists in bandung-v2 (runt). Once this is merged, the fix can be backported.