### PR TITLE
Add CodeCell component with editor and output area

### DIFF
--- a/app/components/CodeCellDemo.tsx
+++ b/app/components/CodeCellDemo.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { CodeCell, type CodeCellData } from "@/registry/cell/CodeCell";
+import type { JupyterOutput } from "@/registry/cell/OutputArea";
+import {
+  EditorRegistryProvider,
+  useEditorRegistry,
+} from "@/registry/cell/useEditorRegistry";
+
+const SAMPLE_CODE = `import numpy as np
+import matplotlib.pyplot as plt
+
+x = np.linspace(0, 10, 100)
+y = np.sin(x)
+
+plt.plot(x, y)
+plt.title("Sine Wave")
+plt.show()`;
+
+const SAMPLE_OUTPUTS: JupyterOutput[] = [
+  {
+    output_type: "execute_result",
+    data: {
+      "text/plain": "<Figure size 640x480 with 1 Axes>",
+    },
+    execution_count: 1,
+  },
+];
+
+/**
+ * Basic demo showing a single CodeCell
+ */
+export function CodeCellBasicDemo() {
+  const [cell, setCell] = useState<CodeCellData>({
+    id: "demo-1",
+    source: SAMPLE_CODE,
+    outputs: [],
+    execution_count: null,
+  });
+  const [isFocused, setIsFocused] = useState(false);
+  const [isExecuting, setIsExecuting] = useState(false);
+
+  const handleExecute = () => {
+    setIsExecuting(true);
+    // Simulate execution
+    setTimeout(() => {
+      setCell((prev) => ({
+        ...prev,
+        outputs: SAMPLE_OUTPUTS,
+        execution_count: (prev.execution_count ?? 0) + 1,
+      }));
+      setIsExecuting(false);
+    }, 1000);
+  };
+
+  return (
+    <div>
+      <CodeCell
+        cell={cell}
+        language="python"
+        isFocused={isFocused}
+        isExecuting={isExecuting}
+        onFocus={() => setIsFocused(true)}
+        onUpdateSource={(source) => setCell((prev) => ({ ...prev, source }))}
+        onExecute={handleExecute}
+        onInterrupt={() => setIsExecuting(false)}
+        onDelete={() => alert("Delete clicked")}
+      />
+    </div>
+  );
+}
+
+/**
+ * Demo showing cell with outputs
+ */
+export function CodeCellWithOutputDemo() {
+  const [cell, setCell] = useState<CodeCellData>({
+    id: "demo-output",
+    source: 'print("Hello, World!")',
+    outputs: [
+      {
+        output_type: "stream",
+        name: "stdout",
+        text: "Hello, World!\n",
+      },
+    ],
+    execution_count: 1,
+  });
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <div>
+      <CodeCell
+        cell={cell}
+        language="python"
+        isFocused={isFocused}
+        onFocus={() => setIsFocused(true)}
+        onUpdateSource={(source) => setCell((prev) => ({ ...prev, source }))}
+        onExecute={() => {}}
+      />
+    </div>
+  );
+}
+
+/**
+ * Multi-cell demo with keyboard navigation
+ */
+function MultiCellContent() {
+  const [cells, setCells] = useState<CodeCellData[]>([
+    {
+      id: "cell-1",
+      source: "# First cell\nx = 1",
+      outputs: [],
+      execution_count: null,
+    },
+    {
+      id: "cell-2",
+      source: "# Second cell\ny = x + 1",
+      outputs: [],
+      execution_count: null,
+    },
+    {
+      id: "cell-3",
+      source: "# Third cell\nprint(y)",
+      outputs: [],
+      execution_count: null,
+    },
+  ]);
+  const [focusedId, setFocusedId] = useState<string | null>("cell-1");
+  const [executingId, setExecutingId] = useState<string | null>(null);
+  const { focusCell } = useEditorRegistry();
+
+  const updateSource = (id: string, source: string) => {
+    setCells((prev) => prev.map((c) => (c.id === id ? { ...c, source } : c)));
+  };
+
+  const executeCell = (id: string) => {
+    setExecutingId(id);
+    setTimeout(() => {
+      setCells((prev) =>
+        prev.map((c) =>
+          c.id === id
+            ? {
+                ...c,
+                execution_count: (c.execution_count ?? 0) + 1,
+                outputs: [
+                  {
+                    output_type: "stream" as const,
+                    name: "stdout" as const,
+                    text: `Executed cell ${id}\n`,
+                  },
+                ],
+              }
+            : c,
+        ),
+      );
+      setExecutingId(null);
+    }, 500);
+  };
+
+  const deleteCell = (id: string) => {
+    if (cells.length <= 1) return;
+    const idx = cells.findIndex((c) => c.id === id);
+    setCells((prev) => prev.filter((c) => c.id !== id));
+    if (idx > 0) {
+      setFocusedId(cells[idx - 1].id);
+    } else if (cells.length > 1) {
+      setFocusedId(cells[1].id);
+    }
+  };
+
+  const handleFocusPrevious = (idx: number, pos: "start" | "end") => {
+    if (idx > 0) {
+      const prevId = cells[idx - 1].id;
+      setFocusedId(prevId);
+      focusCell(prevId, pos);
+    }
+  };
+
+  const handleFocusNext = (idx: number, pos: "start" | "end") => {
+    if (idx < cells.length - 1) {
+      const nextId = cells[idx + 1].id;
+      setFocusedId(nextId);
+      focusCell(nextId, pos);
+    }
+  };
+
+  const insertCellAfter = (idx: number) => {
+    const newId = `cell-${Date.now()}`;
+    const newCell: CodeCellData = {
+      id: newId,
+      source: "",
+      outputs: [],
+      execution_count: null,
+    };
+    setCells((prev) => [
+      ...prev.slice(0, idx + 1),
+      newCell,
+      ...prev.slice(idx + 1),
+    ]);
+    setFocusedId(newId);
+  };
+
+  return (
+    <div>
+      {cells.map((cell, idx) => (
+        <CodeCell
+          key={cell.id}
+          cell={cell}
+          language="python"
+          isFocused={focusedId === cell.id}
+          isExecuting={executingId === cell.id}
+          onFocus={() => setFocusedId(cell.id)}
+          onUpdateSource={(source) => updateSource(cell.id, source)}
+          onExecute={() => executeCell(cell.id)}
+          onInterrupt={() => setExecutingId(null)}
+          onDelete={() => deleteCell(cell.id)}
+          onFocusPrevious={(pos) => handleFocusPrevious(idx, pos)}
+          onFocusNext={(pos) => handleFocusNext(idx, pos)}
+          onInsertCellAfter={() => insertCellAfter(idx)}
+          isLastCell={idx === cells.length - 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function CodeCellMultiDemo() {
+  return (
+    <EditorRegistryProvider>
+      <MultiCellContent />
+    </EditorRegistryProvider>
+  );
+}

--- a/app/components/MarkdownCellDemo.tsx
+++ b/app/components/MarkdownCellDemo.tsx
@@ -30,7 +30,7 @@ export function MarkdownCellBasicDemo() {
   const [isFocused, setIsFocused] = useState(false);
 
   return (
-    <div className="border rounded-lg overflow-hidden">
+    <div>
       <MarkdownCell
         cell={{ id: "demo-1", source }}
         isFocused={isFocused}
@@ -50,7 +50,7 @@ export function MarkdownCellEmptyDemo() {
   const [isFocused, setIsFocused] = useState(true);
 
   return (
-    <div className="border rounded-lg overflow-hidden">
+    <div>
       <MarkdownCell
         cell={{ id: "demo-empty", source }}
         isFocused={isFocused}
@@ -126,21 +126,20 @@ function MultiCellContent() {
   };
 
   return (
-    <div className="space-y-2">
+    <div>
       {cells.map((cell, idx) => (
-        <div key={cell.id} className="border rounded-lg overflow-hidden">
-          <MarkdownCell
-            cell={cell}
-            isFocused={focusedId === cell.id}
-            onFocus={() => setFocusedId(cell.id)}
-            onUpdateSource={(source) => updateSource(cell.id, source)}
-            onDelete={() => deleteCell(cell.id)}
-            onFocusPrevious={(pos) => handleFocusPrevious(idx, pos)}
-            onFocusNext={(pos) => handleFocusNext(idx, pos)}
-            onInsertCellAfter={() => insertCellAfter(idx)}
-            isLastCell={idx === cells.length - 1}
-          />
-        </div>
+        <MarkdownCell
+          key={cell.id}
+          cell={cell}
+          isFocused={focusedId === cell.id}
+          onFocus={() => setFocusedId(cell.id)}
+          onUpdateSource={(source) => updateSource(cell.id, source)}
+          onDelete={() => deleteCell(cell.id)}
+          onFocusPrevious={(pos) => handleFocusPrevious(idx, pos)}
+          onFocusNext={(pos) => handleFocusNext(idx, pos)}
+          onInsertCellAfter={() => insertCellAfter(idx)}
+          isLastCell={idx === cells.length - 1}
+        />
       ))}
     </div>
   );

--- a/content/docs/cell/code-cell.mdx
+++ b/content/docs/cell/code-cell.mdx
@@ -1,0 +1,188 @@
+---
+title: Code Cell
+description: Executable code cell with editor and output area
+icon: Code
+---
+
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { RegistrySetup } from '@/components/docs/registry-setup';
+import { CodeCellBasicDemo, CodeCellWithOutputDemo, CodeCellMultiDemo } from '@/app/components/CodeCellDemo';
+
+<div className="my-8">
+  <CodeCellBasicDemo />
+</div>
+
+The `CodeCell` component provides a complete code cell experience with editor, execution button, and output rendering. Click the play button or press Shift+Enter to "execute".
+
+## Features
+
+- **CodeMirror editor** with language syntax highlighting
+- **Execution button** with count display (`[n]:` style)
+- **Output rendering** via isolated iframe
+- **Keyboard shortcuts** for execute, navigate, delete
+- **Optional navigation** for multi-cell notebooks
+
+## Installation
+
+<RegistrySetup name="code-cell" />
+
+## Usage
+
+### Basic Usage
+
+```tsx
+import { CodeCell } from "@/registry/cell/CodeCell";
+
+function MyComponent() {
+  const [cell, setCell] = useState({
+    id: "cell-1",
+    source: "print('hello')",
+    outputs: [],
+    execution_count: null,
+  });
+
+  return (
+    <CodeCell
+      cell={cell}
+      language="python"
+      onUpdateSource={(source) => setCell({ ...cell, source })}
+      onExecute={() => runCell(cell.id)}
+    />
+  );
+}
+```
+
+### With Outputs
+
+<CodeCellWithOutputDemo />
+
+```tsx
+<CodeCell
+  cell={{
+    id: "cell-1",
+    source: 'print("Hello!")',
+    outputs: [
+      { output_type: "stream", name: "stdout", text: "Hello!\n" }
+    ],
+    execution_count: 1,
+  }}
+  onUpdateSource={setSource}
+  onExecute={execute}
+/>
+```
+
+### Multi-Cell Notebook
+
+<CodeCellMultiDemo />
+
+```tsx
+import { CodeCell } from "@/registry/cell/CodeCell";
+import {
+  EditorRegistryProvider,
+  useEditorRegistry,
+} from "@/registry/cell/useEditorRegistry";
+
+function Notebook() {
+  const [cells, setCells] = useState([...]);
+  const [focusedId, setFocusedId] = useState(cells[0].id);
+  const [executingId, setExecutingId] = useState(null);
+
+  return (
+    <EditorRegistryProvider>
+      {cells.map((cell, idx) => (
+        <CodeCell
+          key={cell.id}
+          cell={cell}
+          language="python"
+          isFocused={focusedId === cell.id}
+          isExecuting={executingId === cell.id}
+          onFocus={() => setFocusedId(cell.id)}
+          onUpdateSource={(source) => updateCell(cell.id, source)}
+          onExecute={() => executeCell(cell.id)}
+          onInterrupt={() => interruptCell(cell.id)}
+          onDelete={() => deleteCell(cell.id)}
+          onFocusPrevious={(pos) => focusPrev(idx, pos)}
+          onFocusNext={(pos) => focusNext(idx, pos)}
+          onInsertCellAfter={() => insertAfter(idx)}
+          isLastCell={idx === cells.length - 1}
+        />
+      ))}
+    </EditorRegistryProvider>
+  );
+}
+```
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Shift+Enter` | Execute and focus next cell |
+| `Mod+Enter` | Execute in place |
+| `Alt+Enter` | Execute and insert new cell |
+| `ArrowUp` (at start) | Focus previous cell |
+| `ArrowDown` (at end) | Focus next cell |
+| `Backspace` (empty cell) | Delete cell and focus previous |
+| `Mod+Shift+F` | Format code (if `onFormat` provided) |
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `cell` | `CodeCellData` | required | Cell data (id, source, outputs, execution_count) |
+| `language` | `SupportedLanguage` | `"python"` | Language for syntax highlighting |
+| `isFocused` | `boolean` | `false` | Whether cell is focused |
+| `isExecuting` | `boolean` | `false` | Whether cell is executing |
+| `onUpdateSource` | `(source: string) => void` | required | Source change callback |
+| `onFocus` | `() => void` | - | Focus callback |
+| `onExecute` | `() => void` | - | Execute callback |
+| `onInterrupt` | `() => void` | - | Interrupt callback |
+| `onDelete` | `() => void` | - | Delete callback |
+| `onFocusPrevious` | `(pos: "start" \| "end") => void` | - | Focus previous cell |
+| `onFocusNext` | `(pos: "start" \| "end") => void` | - | Focus next cell |
+| `onInsertCellAfter` | `() => void` | - | Insert cell after |
+| `onFormat` | `() => void` | - | Format code callback |
+| `isLastCell` | `boolean` | `false` | Affects navigation behavior |
+| `extensions` | `Extension[]` | - | Additional CodeMirror extensions |
+| `useReactRenderer` | `boolean` | `true` | Use React renderer in output iframe |
+| `rendererCode` | `string` | - | Inline renderer bundle |
+| `rendererCss` | `string` | - | Inline renderer CSS |
+| `className` | `string` | - | Additional CSS classes |
+
+## Cell Data Shape
+
+```typescript
+interface CodeCellData {
+  id: string;
+  source: string;
+  outputs: JupyterOutput[];
+  execution_count: number | null;
+}
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ CodeCell                                                │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ CellContainer (cellType="code")                     │ │
+│ │ ┌───────┬───────────────────────────────┬─────────┐ │ │
+│ │ │ [n]:▶ │ CodeMirrorEditor              │   [🗑]  │ │ │
+│ │ │       │ └── keyMap (navigation)       │         │ │ │
+│ │ │   ▮   │ └── extensions (custom)       │         │ │ │
+│ │ ├───────┴───────────────────────────────┴─────────┤ │ │
+│ │ │ OutputArea                                      │ │ │
+│ │ │ └── IsolatedFrame (for rich outputs)            │ │ │
+│ │ └─────────────────────────────────────────────────┘ │ │
+│ └─────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Differences from MarkdownCell
+
+| Feature | CodeCell | MarkdownCell |
+|---------|----------|--------------|
+| Editor | Always visible | Toggle edit/view |
+| Output | Separate area below | Rendered in-place |
+| Execute | Calls `onExecute` | No execution |
+| Gutter | `[n]:` with play button | Just `md` label |

--- a/content/docs/cell/meta.json
+++ b/content/docs/cell/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "cell-container",
     "markdown-cell",
+    "code-cell",
     "cell-controls",
     "cell-header",
     "collaborator-avatars",

--- a/registry/cell/CodeCell.tsx
+++ b/registry/cell/CodeCell.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import type { KeyBinding } from "@codemirror/view";
+import { Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import {
+  CodeMirrorEditor,
+  type CodeMirrorEditorRef,
+} from "@/registry/editor/codemirror-editor";
+import type { SupportedLanguage } from "@/registry/editor/languages";
+import { CellContainer } from "./CellContainer";
+import { CompactExecutionButton } from "./CompactExecutionButton";
+import type { JupyterOutput } from "./OutputArea";
+import { OutputArea } from "./OutputArea";
+import { useCellKeyboardNavigation } from "./useCellKeyboardNavigation";
+import { useEditorRegistryOptional } from "./useEditorRegistry";
+
+/**
+ * Code cell data shape (matches Jupyter nbformat)
+ */
+export interface CodeCellData {
+  id: string;
+  source: string;
+  outputs: JupyterOutput[];
+  execution_count: number | null;
+}
+
+interface CodeCellProps {
+  /**
+   * The cell data containing id, source, outputs, and execution count
+   */
+  cell: CodeCellData;
+  /**
+   * Programming language for syntax highlighting
+   * @default "python"
+   */
+  language?: SupportedLanguage;
+  /**
+   * Whether this cell is focused
+   */
+  isFocused?: boolean;
+  /**
+   * Whether the cell is currently executing
+   */
+  isExecuting?: boolean;
+  /**
+   * Callback when cell is focused
+   */
+  onFocus?: () => void;
+  /**
+   * Callback when source content changes
+   */
+  onUpdateSource: (source: string) => void;
+  /**
+   * Callback to execute the cell
+   */
+  onExecute?: () => void;
+  /**
+   * Callback to interrupt execution
+   */
+  onInterrupt?: () => void;
+  /**
+   * Callback to delete the cell
+   */
+  onDelete?: () => void;
+  /**
+   * Callback to focus previous cell (for keyboard navigation)
+   */
+  onFocusPrevious?: (cursorPosition: "start" | "end") => void;
+  /**
+   * Callback to focus next cell (for keyboard navigation)
+   */
+  onFocusNext?: (cursorPosition: "start" | "end") => void;
+  /**
+   * Callback to insert a new cell after this one
+   */
+  onInsertCellAfter?: () => void;
+  /**
+   * Callback to format the cell code
+   */
+  onFormat?: () => void;
+  /**
+   * Whether this is the last cell (affects Enter behavior)
+   */
+  isLastCell?: boolean;
+  /**
+   * Additional CodeMirror extensions
+   */
+  extensions?: Parameters<typeof CodeMirrorEditor>[0]["extensions"];
+  /**
+   * Whether to use the React renderer bundle inside the iframe for outputs.
+   * @default true
+   */
+  useReactRenderer?: boolean;
+  /**
+   * Inline renderer JavaScript bundle for the iframe.
+   */
+  rendererCode?: string;
+  /**
+   * Inline renderer CSS for the iframe.
+   */
+  rendererCss?: string;
+  /**
+   * Additional class name for the container
+   */
+  className?: string;
+}
+
+/**
+ * CodeCell renders a code cell with editor and output area.
+ *
+ * Features:
+ * - CodeMirror editor with language syntax highlighting
+ * - Execution count display with play/interrupt button
+ * - Output rendering via OutputArea (with isolation support)
+ * - Keyboard shortcuts for execute, navigate, delete
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <CodeCell
+ *   cell={{ id: "1", source: "print('hi')", outputs: [], execution_count: null }}
+ *   onUpdateSource={setSource}
+ *   onExecute={() => runCell(id)}
+ * />
+ *
+ * // With navigation (in a notebook)
+ * <EditorRegistryProvider>
+ *   {cells.map((cell, i) => (
+ *     <CodeCell
+ *       key={cell.id}
+ *       cell={cell}
+ *       isFocused={focusedId === cell.id}
+ *       isExecuting={executingId === cell.id}
+ *       onFocus={() => setFocusedId(cell.id)}
+ *       onUpdateSource={(source) => updateCell(cell.id, source)}
+ *       onExecute={() => executeCell(cell.id)}
+ *       onInterrupt={() => interruptCell(cell.id)}
+ *       onDelete={() => deleteCell(cell.id)}
+ *       onFocusPrevious={(pos) => focusPrev(i, pos)}
+ *       onFocusNext={(pos) => focusNext(i, pos)}
+ *     />
+ *   ))}
+ * </EditorRegistryProvider>
+ * ```
+ */
+export function CodeCell({
+  cell,
+  language = "python",
+  isFocused = false,
+  isExecuting = false,
+  onFocus,
+  onUpdateSource,
+  onExecute,
+  onInterrupt,
+  onDelete,
+  onFocusPrevious,
+  onFocusNext,
+  onInsertCellAfter,
+  onFormat,
+  isLastCell = false,
+  extensions,
+  useReactRenderer = true,
+  rendererCode,
+  rendererCss,
+  className,
+}: CodeCellProps) {
+  const editorRef = useRef<CodeMirrorEditorRef>(null);
+
+  // Optional editor registry for cross-cell navigation
+  const registry = useEditorRegistryOptional();
+
+  // Register editor with the registry for cross-cell navigation
+  useEffect(() => {
+    if (editorRef.current && registry) {
+      registry.registerEditor(cell.id, {
+        focus: () => editorRef.current?.focus(),
+        setCursorPosition: (position) =>
+          editorRef.current?.setCursorPosition(position),
+      });
+    }
+    return () => registry?.unregisterEditor(cell.id);
+  }, [cell.id, registry]);
+
+  // Handle focus next, creating a new cell if at the end
+  const handleFocusNextOrCreate = useCallback(
+    (cursorPosition: "start" | "end") => {
+      if (isLastCell && onInsertCellAfter) {
+        onInsertCellAfter();
+      } else if (onFocusNext) {
+        onFocusNext(cursorPosition);
+      }
+    },
+    [isLastCell, onFocusNext, onInsertCellAfter],
+  );
+
+  // Get keyboard navigation bindings
+  const navigationKeyMap = useCellKeyboardNavigation({
+    onFocusPrevious: onFocusPrevious ?? (() => {}),
+    onFocusNext: handleFocusNextOrCreate,
+    onExecute,
+    onExecuteAndInsert: onInsertCellAfter
+      ? () => {
+          onExecute?.();
+          onInsertCellAfter();
+        }
+      : undefined,
+    onDelete,
+    onFormat,
+  });
+
+  const keyMap: KeyBinding[] = useMemo(
+    () => [...navigationKeyMap],
+    [navigationKeyMap],
+  );
+
+  const handleExecute = useCallback(() => {
+    onExecute?.();
+  }, [onExecute]);
+
+  const gutterContent = (
+    <CompactExecutionButton
+      count={cell.execution_count}
+      isExecuting={isExecuting}
+      onExecute={handleExecute}
+      onInterrupt={onInterrupt}
+    />
+  );
+
+  const rightGutterContent = onDelete ? (
+    <button
+      type="button"
+      onClick={onDelete}
+      className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
+      title="Delete cell"
+    >
+      <Trash2 className="h-3.5 w-3.5" />
+    </button>
+  ) : undefined;
+
+  return (
+    <CellContainer
+      id={cell.id}
+      cellType="code"
+      isFocused={isFocused}
+      onFocus={onFocus}
+      gutterContent={gutterContent}
+      rightGutterContent={rightGutterContent}
+      className={className}
+      codeContent={
+        <div>
+          <CodeMirrorEditor
+            ref={editorRef}
+            value={cell.source}
+            language={language}
+            onValueChange={onUpdateSource}
+            keyMap={keyMap}
+            extensions={extensions}
+            placeholder="Enter code..."
+            className="min-h-[2rem]"
+            autoFocus={isFocused}
+          />
+        </div>
+      }
+      outputContent={
+        <OutputArea
+          outputs={cell.outputs}
+          preloadIframe
+          useReactRenderer={useReactRenderer}
+          rendererCode={rendererCode}
+          rendererCss={rendererCss}
+        />
+      }
+      hideOutput={cell.outputs.length === 0}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Extract reusable code cell component from bandung-v2.

## Features

- CodeMirror editor with language syntax highlighting
- `[n]:` execution count with play/interrupt button
- OutputArea for rendering execution outputs
- Keyboard shortcuts (Shift+Enter, Mod+Enter, navigation)
- Optional navigation callbacks for multi-cell notebooks

## Simplified from bandung-v2

Removed app-specific features:
- Kernel completion extension
- History search dialog (Ctrl+R)
- Page payload display (? / ?? documentation)

Kept the core architecture that can be extended by consuming apps.

## Documentation

- New docs page at `/docs/cell/code-cell`
- Basic demo, output demo, multi-cell demo
- Props table and keyboard shortcuts