### PR TITLE
Add ErrorBoundary for per-output and per-widget fault isolation

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -344,7 +344,8 @@
         "@nteract/ansi-output",
         "@nteract/isolated-frame",
         "@nteract/widget-store",
-        "@nteract/markdown-output"
+        "@nteract/markdown-output",
+        "@nteract/error-boundary"
       ],
       "files": [
         {
@@ -503,7 +504,8 @@
       "description": "Universal widget router that renders Jupyter widgets. Routes anywidgets to ESM loader and standard ipywidgets to built-in shadcn-backed components.",
       "registryDependencies": [
         "@nteract/widget-store",
-        "@nteract/anywidget-view"
+        "@nteract/anywidget-view",
+        "@nteract/error-boundary"
       ],
       "files": [
         {
@@ -915,6 +917,29 @@
           "path": "registry/cell/CellTypeSelector.tsx",
           "type": "registry:component",
           "target": "components/cell/CellTypeSelector.tsx"
+        }
+      ]
+    },
+    {
+      "name": "error-boundary",
+      "type": "registry:lib",
+      "title": "Error Boundary",
+      "description": "React error boundary with resetKeys support for automatic recovery. Includes OutputErrorFallback and WidgetErrorFallback components for graceful error display in outputs and widgets.",
+      "files": [
+        {
+          "path": "registry/lib/error-boundary.tsx",
+          "type": "registry:lib",
+          "target": "lib/error-boundary.tsx"
+        },
+        {
+          "path": "registry/lib/output-error-fallback.tsx",
+          "type": "registry:lib",
+          "target": "lib/output-error-fallback.tsx"
+        },
+        {
+          "path": "registry/lib/widget-error-fallback.tsx",
+          "type": "registry:lib",
+          "target": "lib/widget-error-fallback.tsx"
         }
       ]
     },

--- a/registry/cell/OutputArea.tsx
+++ b/registry/cell/OutputArea.tsx
@@ -10,6 +10,8 @@ import {
   useState,
 } from "react";
 import { cn } from "@/lib/utils";
+import { ErrorBoundary } from "@/registry/lib/error-boundary";
+import { OutputErrorFallback } from "@/registry/lib/output-error-fallback";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
@@ -504,9 +506,28 @@ export function OutputArea({
 
           {/* In-DOM outputs (when not using isolation) */}
           {!shouldIsolate &&
-            outputs.map((output, index) =>
-              renderOutput(output, index, renderers, priority),
-            )}
+            outputs.map((output, index) => (
+              <ErrorBoundary
+                key={`output-${index}`}
+                resetKeys={[JSON.stringify(output)]}
+                fallback={(error, reset) => (
+                  <OutputErrorFallback
+                    error={error}
+                    outputIndex={index}
+                    onRetry={reset}
+                  />
+                )}
+                onError={(error, errorInfo) => {
+                  console.error(
+                    `[OutputArea] Error rendering output ${index}:`,
+                    error,
+                    errorInfo.componentStack,
+                  );
+                }}
+              >
+                {renderOutput(output, index, renderers, priority)}
+              </ErrorBoundary>
+            ))}
         </div>
       )}
     </div>

--- a/registry/isolated-renderer/index.tsx
+++ b/registry/isolated-renderer/index.tsx
@@ -15,6 +15,10 @@ import { createRoot, type Root } from "react-dom/client";
 // Import styles (Tailwind + theme variables)
 import "./styles.css";
 
+// Import error boundary for fault isolation
+import { ErrorBoundary } from "@/registry/lib/error-boundary";
+import { OutputErrorFallback } from "@/registry/lib/output-error-fallback";
+
 // Import output components directly (not through MediaRouter's lazy loading)
 // This ensures all components are bundled inline for the isolated iframe
 import {
@@ -194,8 +198,33 @@ function IsolatedRendererApp() {
       className="isolated-renderer"
       data-theme={state.isDark ? "dark" : "light"}
     >
-      {state.outputs.map((entry) => (
-        <OutputRenderer key={entry.id} payload={entry.payload} />
+      {state.outputs.map((entry, index) => (
+        <ErrorBoundary
+          key={entry.id}
+          resetKeys={[JSON.stringify(entry.payload)]}
+          fallback={(error, reset) => (
+            <OutputErrorFallback
+              error={error}
+              outputIndex={index}
+              onRetry={reset}
+            />
+          )}
+          onError={(error, errorInfo) => {
+            // Send error back to parent
+            window.parent.postMessage(
+              {
+                type: "error",
+                payload: {
+                  message: error.message,
+                  stack: errorInfo.componentStack,
+                },
+              },
+              "*",
+            );
+          }}
+        >
+          <OutputRenderer payload={entry.payload} />
+        </ErrorBoundary>
       ))}
     </div>
   );

--- a/registry/lib/__tests__/error-boundary.test.tsx
+++ b/registry/lib/__tests__/error-boundary.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "../error-boundary";
+
+// Component that throws an error when shouldThrow is true
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test error");
+  }
+  return <div>Child content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary fallback={() => <div>Error fallback</div>}>
+        <div>Child content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("renders fallback when an error occurs", () => {
+    // Suppress console.error for this test
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={(error) => <div>Error: {error.message}</div>}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Error: Test error")).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it("calls onError when an error occurs", () => {
+    const onError = vi.fn();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={() => <div>Fallback</div>} onError={onError}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
+    spy.mockRestore();
+  });
+
+  it("resets error state when resetErrorBoundary is called", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { rerender } = render(
+      <ErrorBoundary
+        fallback={(error, reset) => <button onClick={reset}>Retry</button>}
+      >
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+
+    // Rerender with non-throwing component, then trigger reset
+    rerender(
+      <ErrorBoundary
+        fallback={(error, reset) => <button onClick={reset}>Retry</button>}
+      >
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByText("Retry"));
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+
+  it("resets error state when resetKeys change", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={["key1"]} fallback={() => <div>Fallback</div>}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Fallback")).toBeInTheDocument();
+
+    // Change resetKeys and provide non-throwing component
+    rerender(
+      <ErrorBoundary resetKeys={["key2"]} fallback={() => <div>Fallback</div>}>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+
+  it("passes error and reset function to fallback", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary
+        fallback={(error, reset) => (
+          <div>
+            <span data-testid="error-message">{error.message}</span>
+            <button data-testid="reset-btn" onClick={reset}>
+              Reset
+            </button>
+          </div>
+        )}
+      >
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId("error-message")).toHaveTextContent("Test error");
+    expect(screen.getByTestId("reset-btn")).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+});

--- a/registry/lib/error-boundary.tsx
+++ b/registry/lib/error-boundary.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Render prop called when an error is caught. Return the fallback UI. */
+  fallback: (error: Error, resetErrorBoundary: () => void) => ReactNode;
+  /** Optional callback when an error is caught. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /**
+   * When any value in this array changes, the error state is automatically
+   * cleared and the children are re-rendered. Use this to recover from
+   * errors when the underlying data changes (e.g., cell re-execution,
+   * new output data, widget state update).
+   */
+  resetKeys?: readonly unknown[];
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  prevResetKeys: readonly unknown[] | undefined;
+}
+
+/**
+ * Reusable React error boundary.
+ *
+ * Catches render errors in child components and displays a fallback UI
+ * via the `fallback` render prop. Provides a `resetErrorBoundary` function
+ * to retry rendering.
+ *
+ * Supports automatic recovery via `resetKeys` — when any key changes,
+ * the error state is cleared and children re-render.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundary
+ *   fallback={(error, reset) => (
+ *     <div>
+ *       <p>Something went wrong: {error.message}</p>
+ *       <button onClick={reset}>Retry</button>
+ *     </div>
+ *   )}
+ *   resetKeys={[executionCount]}
+ * >
+ *   <MyComponent />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null, prevResetKeys: props.resetKeys };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState,
+  ): Partial<ErrorBoundaryState> | null {
+    if (
+      state.error &&
+      state.prevResetKeys !== undefined &&
+      props.resetKeys !== undefined
+    ) {
+      const changed =
+        props.resetKeys.length !== state.prevResetKeys.length ||
+        props.resetKeys.some(
+          (key, i) => !Object.is(key, state.prevResetKeys![i]),
+        );
+      if (changed) {
+        return { error: null, prevResetKeys: props.resetKeys };
+      }
+    }
+    // Always track latest resetKeys even when not in error state
+    if (props.resetKeys !== state.prevResetKeys) {
+      return { prevResetKeys: props.resetKeys };
+    }
+    return null;
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("[ErrorBoundary]", error, errorInfo.componentStack);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  resetErrorBoundary = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      return this.props.fallback(this.state.error, this.resetErrorBoundary);
+    }
+    return this.props.children;
+  }
+}

--- a/registry/lib/output-error-fallback.tsx
+++ b/registry/lib/output-error-fallback.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export interface OutputErrorFallbackProps {
+  /** The error that was caught */
+  error: Error;
+  /** Optional index of the output (0-based) for display */
+  outputIndex?: number;
+  /** Callback to retry rendering */
+  onRetry?: () => void;
+}
+
+/**
+ * Fallback UI for output rendering errors.
+ *
+ * Displays an error message with optional retry button.
+ * Styled to match AnsiErrorOutput patterns.
+ */
+export function OutputErrorFallback({
+  error,
+  outputIndex,
+  onRetry,
+}: OutputErrorFallbackProps) {
+  return (
+    <div
+      data-slot="output-error"
+      className={cn(
+        "border-l-2 border-red-200 dark:border-red-800 py-3 pl-3 pr-2",
+        "rounded-r bg-red-50/50 dark:bg-red-950/20",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-sm font-medium text-red-700 dark:text-red-400">
+            Output rendering failed
+            {outputIndex !== undefined && ` (output ${outputIndex + 1})`}
+          </div>
+          <div className="mt-1 font-mono text-xs text-red-600/80 dark:text-red-400/70">
+            {error.message}
+          </div>
+        </div>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="text-xs text-red-600 underline hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/registry/lib/widget-error-fallback.tsx
+++ b/registry/lib/widget-error-fallback.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export interface WidgetErrorFallbackProps {
+  /** The error that was caught */
+  error: Error;
+  /** The widget model ID */
+  modelId: string;
+  /** Optional widget model name for display */
+  modelName?: string;
+  /** Callback to retry rendering */
+  onRetry?: () => void;
+}
+
+/**
+ * Fallback UI for widget rendering errors.
+ *
+ * Displays an error message with optional retry button.
+ * Styled to match UnsupportedWidget patterns.
+ */
+export function WidgetErrorFallback({
+  error,
+  modelId,
+  modelName,
+  onRetry,
+}: WidgetErrorFallbackProps) {
+  return (
+    <div
+      className={cn(
+        "rounded border border-dashed border-red-300 p-3 text-sm dark:border-red-800",
+        "bg-red-50/50 dark:bg-red-950/20",
+      )}
+      data-widget-id={modelId}
+      data-widget-error="true"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="font-medium text-red-700 dark:text-red-400">
+            Widget error{modelName && `: ${modelName}`}
+          </div>
+          <div className="mt-1 font-mono text-xs text-red-600/70 dark:text-red-400/60">
+            {error.message}
+          </div>
+        </div>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="text-xs text-red-600 underline hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/registry/widgets/widget-view.tsx
+++ b/registry/widgets/widget-view.tsx
@@ -10,6 +10,8 @@
  */
 
 import { cn } from "@/lib/utils";
+import { ErrorBoundary } from "@/registry/lib/error-boundary";
+import { WidgetErrorFallback } from "@/registry/lib/widget-error-fallback";
 import { AnyWidgetView, isAnyWidget } from "./anywidget-view";
 import { useLayoutStyles } from "./use-layout-styles";
 import { getWidgetComponent } from "./widget-registry";
@@ -116,13 +118,37 @@ export function WidgetView({ modelId, className }: WidgetViewProps) {
     }
   }
 
+  // Wrap with ErrorBoundary for fault isolation
+  const wrappedWidget = (
+    <ErrorBoundary
+      resetKeys={[model.state ? JSON.stringify(model.state) : modelId]}
+      fallback={(error, reset) => (
+        <WidgetErrorFallback
+          error={error}
+          modelId={modelId}
+          modelName={model.modelName}
+          onRetry={reset}
+        />
+      )}
+      onError={(error, errorInfo) => {
+        console.error(
+          `[WidgetView] Error rendering widget ${modelId}:`,
+          error,
+          errorInfo.componentStack,
+        );
+      }}
+    >
+      {renderedWidget}
+    </ErrorBoundary>
+  );
+
   // Wrap with layout positioning if the widget has grid placement styles
   const hasChildStyles = Object.keys(childStyle).length > 0;
   if (hasChildStyles) {
-    return <div style={childStyle}>{renderedWidget}</div>;
+    return <div style={childStyle}>{wrappedWidget}</div>;
   }
 
-  return renderedWidget;
+  return wrappedWidget;
 }
 
 export default WidgetView;


### PR DESCRIPTION
## Summary

Adds error boundaries to OutputArea, WidgetView, and isolated renderer to provide per-output and per-widget fault isolation. Prevents single render errors from crashing the entire component tree.

## Changes

- **ErrorBoundary component** (`registry/lib/error-boundary.tsx`): Catches render errors with support for `resetKeys` auto-recovery and error callbacks
- **Fallback UI components**: OutputErrorFallback and WidgetErrorFallback display graceful error messages with retry buttons
- **OutputArea integration**: Wraps each output in an ErrorBoundary (in-DOM mode)
- **WidgetView integration**: Wraps rendered widgets with ErrorBoundary, auto-recovers on state changes
- **Isolated renderer integration**: Wraps each OutputRenderer with ErrorBoundary, reports errors to parent
- **Registry entry**: Added error-boundary library to registry with proper dependencies

## Test Plan

- [x] Unit tests for ErrorBoundary (6 tests covering error catching, resetKeys, callbacks)
- [x] Type checking passes
- [x] Registry validation passes
- [x] Isolated renderer rebuilds successfully
- [ ] Manual testing with OutputArea demos (verify no regressions)
- [ ] Manual testing with widget demos (verify error handling)

Closes #169 #170